### PR TITLE
Ensure dry run avoids database writes

### DIFF
--- a/wplms-s1-importer/wplms-s1-importer.php
+++ b/wplms-s1-importer/wplms-s1-importer.php
@@ -228,7 +228,9 @@ namespace WPLMS_S1I {
 				if ( $aid ) $stats['orphans_assignments']++;
 			}
 
-			\update_option( \WPLMS_S1I_OPT_RUNSTATS, $stats, false );
+                        if ( ! $this->dry_run ) {
+                                \update_option( \WPLMS_S1I_OPT_RUNSTATS, $stats, false );
+                        }
 			$this->logger->write( 'Import finished', $stats );
 			return $stats;
 		}
@@ -457,14 +459,17 @@ namespace WPLMS_S1I {
 			return $new_id;
 		}
 
-		private function stash_enrollments( $course, $enrollments ) {
-			if ( empty( $enrollments ) ) return;
-			$pool = \get_option( \WPLMS_S1I_OPT_ENROLL_POOL, [] );
-			$old_id = array_get( $course, 'id', null );
-			$pool[ (string) $old_id ] = $enrollments; // kept verbatim; will be resolved once users are mapped
-			\update_option( \WPLMS_S1I_OPT_ENROLL_POOL, $pool, false );
-			$this->logger->write( 'enrollments stashed', [ 'course_old_id'=>$old_id, 'count'=>count( (array) $enrollments ) ] );
-		}
+                private function stash_enrollments( $course, $enrollments ) {
+                        if ( $this->dry_run ) {
+                                return;
+                        }
+                        if ( empty( $enrollments ) ) return;
+                        $pool = \get_option( \WPLMS_S1I_OPT_ENROLL_POOL, [] );
+                        $old_id = array_get( $course, 'id', null );
+                        $pool[ (string) $old_id ] = $enrollments; // kept verbatim; will be resolved once users are mapped
+                        \update_option( \WPLMS_S1I_OPT_ENROLL_POOL, $pool, false );
+                        $this->logger->write( 'enrollments stashed', [ 'course_old_id'=>$old_id, 'count'=>count( (array) $enrollments ) ] );
+                }
 	}
 
 	// ------------------------------ Admin UI -----------------------------------


### PR DESCRIPTION
## Summary
- Skip persisting run stats when dry run is enabled
- Bail from stashing enrollments during dry runs to avoid option updates

## Testing
- `php -l wplms-s1-importer/wplms-s1-importer.php`
- `php -d detect_unicode=0 <<'PHP'
<?php
// stub WP environment

define('ABSPATH', __DIR__);
function plugin_dir_path($file){ return __DIR__.'/'; }
function plugin_dir_url($file){ return 'http://example.com/'; }
function wp_upload_dir(){ return ['basedir'=>sys_get_temp_dir()]; }
function trailingslashit($p){ return rtrim($p,'/').'/'; }
function wp_mkdir_p($dir){ return true; }
function get_option($name,$default=false){ return $default; }
function add_action($hook, $callback){ }
function is_admin(){ return false; }
function wp_json_encode($data){ return json_encode($data); }
function sanitize_title($title){ return strtolower(str_replace(' ','-',$title)); }

$update_option_calls = 0;
function update_option($name,$value,$autoload=null){ global $update_option_calls; $update_option_calls++; }
$wp_insert_post_calls = 0;
function wp_insert_post($args,$wp_error=false){ global $wp_insert_post_calls; $wp_insert_post_calls++; return 101; }
$update_post_meta_calls = 0;
function update_post_meta($id,$key,$value){ global $update_post_meta_calls; $update_post_meta_calls++; }

require 'wplms-s1-importer/wplms-s1-importer.php';
$logger = new WPLMS_S1I\Logger();
$idmap = new WPLMS_S1I\IdMap();
$importer = new WPLMS_S1I\Importer($logger,$idmap);
$importer->set_dry_run(true);
$payload = ['courses'=>[['id'=>1,'title'=>'Course','enrollments'=>['user1']]]];
$importer->run($payload);
echo "update_option_calls_after_run=$update_option_calls\n";
echo "wp_insert_post_calls=$wp_insert_post_calls\n";
echo "update_post_meta_calls=$update_post_meta_calls\n";

$update_option_calls = 0;
$ref = new ReflectionClass($importer);
$m = $ref->getMethod('stash_enrollments');
$m->setAccessible(true);
$m->invoke($importer,['id'=>1],['user2']);
echo "update_option_calls_after_direct_stash=$update_option_calls\n";
?>
PHP`

------
https://chatgpt.com/codex/tasks/task_e_68b5ab4ece70832ab4fd0ccf75824c9b