### PR TITLE
Importer: accept only JSON uploads

### DIFF
--- a/wplms-s1-importer/includes/Importer.php
+++ b/wplms-s1-importer/includes/Importer.php
@@ -82,42 +82,21 @@ class Importer {
 			return $stats;
 		}
 
-		private function load_payload( $path ) {
-			$ext = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
-			if ( 'zip' === $ext ) {
-				if ( ! class_exists( '\\ZipArchive' ) ) {
-					throw new \RuntimeException( 'ZipArchive not available on server.' );
-				}
-				$zip = new \ZipArchive();
-				if ( true !== $zip->open( $path ) ) {
-					throw new \RuntimeException( 'Unable to open zip file.' );
-				}
-				$json = null;
-				for ( $i = 0; $i < $zip->numFiles; $i++ ) {
-					$name = $zip->getNameIndex( $i );
-					if ( substr( $name, -5 ) === '.json' ) {
-						$json = $zip->getFromIndex( $i );
-						break;
-					}
-				}
-				$zip->close();
-				if ( ! $json ) throw new \RuntimeException( 'No JSON found inside zip.' );
-				$payload = json_decode( $json, true );
-				if ( json_last_error() !== JSON_ERROR_NONE ) {
-					throw new \RuntimeException( 'Invalid JSON in zip: ' . json_last_error_msg() );
-				}
-				return $payload;
-			}
-			if ( 'json' === $ext ) {
-				$raw = file_get_contents( $path );
-				$payload = json_decode( $raw, true );
-				if ( json_last_error() !== JSON_ERROR_NONE ) {
-					throw new \RuntimeException( 'Invalid JSON: ' . json_last_error_msg() );
-				}
-				return $payload;
-			}
-			throw new \RuntimeException( 'Unsupported file type: ' . $ext );
-		}
+                private function load_payload( $path ) {
+                        $ext = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+                        if ( 'json' !== $ext ) {
+                                throw new \RuntimeException( 'Unsupported file type: ' . $ext );
+                        }
+                        $raw = file_get_contents( $path );
+                        if ( false === $raw ) {
+                                throw new \RuntimeException( 'Unable to read file.' );
+                        }
+                        $payload = json_decode( $raw, true );
+                        if ( json_last_error() !== JSON_ERROR_NONE ) {
+                                throw new \RuntimeException( 'Invalid JSON: ' . json_last_error_msg() );
+                        }
+                        return $payload;
+                }
 
                 private function import_course( $course ) {
                         $old_id   = (int) array_get( $course, 'old_id', 0 );

--- a/wplms-s1-importer/wplms-s1-importer.php
+++ b/wplms-s1-importer/wplms-s1-importer.php
@@ -67,16 +67,16 @@ add_action( 'init', function () {
     }
 } );
 
-// Optional: WP‑CLI command for local usage: wp wplms-s1 import <path.json|zip> [--dry]
+// Optional: WP‑CLI command for local usage: wp wplms-s1 import <path.json> [--dry]
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
     \WP_CLI::add_command( 'wplms-s1', new class {
         /**
-         * Import from a JSON or ZIP exported by WPLMS S1 Exporter.
+         * Import from a JSON exported by WPLMS S1 Exporter.
          *
          * ## OPTIONS
          *
          * <path>
-         * : Absolute path to JSON or ZIP file.
+         * : Absolute path to JSON file.
          *
          * [--dry]
          * : Analyze only; do not create posts.


### PR DESCRIPTION
## Summary
- accept only JSON files in importer form and update admin notice logic
- remove ZIP handling and simplify payload loading to JSON only
- document JSON-only support in WP-CLI command

## Testing
- `php -l wplms-s1-importer/includes/Admin.php`
- `php -l wplms-s1-importer/includes/Importer.php`
- `php -l wplms-s1-importer/wplms-s1-importer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b5b224cf38832a8fb142cbd6dd8582