### PR TITLE
Add product pricing to course meta

### DIFF
--- a/wplms-s1-exporter/wplms-s1-exporter.php
+++ b/wplms-s1-exporter/wplms-s1-exporter.php
@@ -229,6 +229,18 @@ class WPLMS_S1_Exporter {
         list($vibe, $vibe_extra, $third_party) = $this->bucketize_meta($raw_meta);
         $access_type = $this->detect_access_type($vibe, $vibe_extra);
 
+        $price = null;
+        $sale_price = null;
+        if ( ! empty($vibe['vibe_product']) ) {
+            $product_id = is_array($vibe['vibe_product']) ? intval(reset($vibe['vibe_product'])) : intval($vibe['vibe_product']);
+            if ( $product_id ) {
+                $regular = get_post_meta($product_id, '_regular_price', true);
+                if ( is_numeric($regular) ) $price = (float) $regular;
+                $sale = get_post_meta($product_id, '_sale_price', true);
+                if ( is_numeric($sale) ) $sale_price = (float) $sale;
+            }
+        }
+
         $thumb_id = get_post_thumbnail_id($course->ID);
         $featured = $thumb_id ? $this->get_attachment_payload($thumb_id) : null;
 
@@ -394,6 +406,8 @@ class WPLMS_S1_Exporter {
                 'access_type' => $access_type,
                 'vibe'        => $vibe,
                 'vibe_extra'  => $vibe_extra,
+                'price'       => $price,
+                'sale_price'  => $sale_price,
                 'misc'        => array( 'third_party' => $third_party ),
             ),
             'curriculum'     => $curriculum,


### PR DESCRIPTION
## Summary
- retrieve WooCommerce `_regular_price` and `_sale_price` for `vibe_product`
- include `price` and `sale_price` fields in exported course meta

## Testing
- `php -l wplms-s1-exporter.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6ccc7a700832a949b664908d02a9b