### PR TITLE
feat: map course pricing and duration

### DIFF
--- a/wplms-s1-importer/includes/IdMap.php
+++ b/wplms-s1-importer/includes/IdMap.php
@@ -6,20 +6,31 @@ class IdMap {
 
     public function __construct() {
         $this->map = \get_option( \WPLMS_S1I_OPT_IDMAP, [
-            'courses'     => [],
-            'units'       => [], // mapped to Lessons in LearnDash
-            'quizzes'     => [],
-            'assignments' => [],
-            'certificates'=> [],
+            'courses'      => [],
+            'units'        => [], // mapped to Lessons in LearnDash
+            'quizzes'      => [],
+            'assignments'  => [],
+            'certificates' => [],
         ] );
     }
 
     public function get_all() { return $this->map; }
 
-    public function get( $type, $old_id ) { return isset( $this->map[ $type ][ $old_id ] ) ? (int) $this->map[ $type ][ $old_id ] : 0; }
+    public function get_entry( $type, $old_id ) {
+        return isset( $this->map[ $type ][ $old_id ] ) ? $this->map[ $type ][ $old_id ] : null;
+    }
 
-    public function set( $type, $old_id, $new_id ) {
-        $this->map[ $type ][ (string) $old_id ] = (int) $new_id;
+    public function get( $type, $old_id ) {
+        $entry = $this->get_entry( $type, $old_id );
+        return $entry ? (int) array_get( $entry, 'id', 0 ) : 0;
+    }
+
+    public function set( $type, $old_id, $new_id, $slug = '' ) {
+        $this->map[ $type ][ (string) $old_id ] = [
+            'id'          => (int) $new_id,
+            'slug'        => (string) $slug,
+            'imported_at' => time(),
+        ];
         \update_option( \WPLMS_S1I_OPT_IDMAP, $this->map, false );
     }
 

--- a/wplms-s1-importer/includes/Importer.php
+++ b/wplms-s1-importer/includes/Importer.php
@@ -19,43 +19,83 @@ class Importer {
         }
 
         $stats = [
-            'courses'=>0,'lessons'=>0,'quizzes'=>0,'assignments'=>0,'certificates'=>0,
-            'orphans_units'=>0,'orphans_quizzes'=>0,'orphans_assignments'=>0,
-            'skipped'=>0,'errors'=>0,
+            'courses_created'       => 0,
+            'courses_updated'       => 0,
+            'lessons_created'       => 0,
+            'lessons_updated'       => 0,
+            'quizzes'               => 0,
+            'assignments'           => 0,
+            'certificates'          => 0,
+            'orphans_units'         => 0,
+            'orphans_quizzes'       => 0,
+            'orphans_assignments'   => 0,
+            'access_free'           => 0,
+            'access_paid'           => 0,
+            'access_closed'         => 0,
+            'access_lead'           => 0,
+            'lifetime_courses'      => 0,
+            'lessons_zero_duration' => 0,
+            'skipped'               => 0,
+            'errors'                => 0,
         ];
 
         // 1) Courses
         $courses = (array) array_get( $payload, 'courses', [] );
         foreach ( $courses as $course ) {
             try {
-                $cid = $this->import_course( $course );
-                $stats['courses']++;
+                $cres = $this->import_course( $course );
+                $cid  = (int) array_get( $cres, 'id', 0 );
+                if ( $cid ) {
+                    if ( array_get( $cres, 'created' ) ) {
+                        $stats['courses_created']++;
+                    } else {
+                        $stats['courses_updated']++;
+                    }
+                    $stats[ 'access_' . array_get( $cres, 'access', 'closed' ) ]++;
+                    if ( array_get( $cres, 'lifetime' ) ) {
+                        $stats['lifetime_courses']++;
+                    }
 
-                // lessons
-                $units = (array) array_get( $course, 'units', [] );
-                $menu_order = 0;
-                foreach ( $units as $unit ) {
-                    $ok = $this->import_lesson( $unit, $cid, $menu_order++ );
-                    if ( $ok ) $stats['lessons']++;
+                    // lessons
+                    $units = (array) array_get( $course, 'units', [] );
+                    $menu_order = 0;
+                    foreach ( $units as $unit ) {
+                        $lres = $this->import_lesson( $unit, $cid, $menu_order++ );
+                        if ( $lres ) {
+                            if ( array_get( $lres, 'created' ) ) {
+                                $stats['lessons_created']++;
+                            } else {
+                                $stats['lessons_updated']++;
+                            }
+                            if ( array_get( $lres, 'zero_duration' ) ) {
+                                $stats['lessons_zero_duration']++;
+                            }
+                        }
+                    }
+
+                    // quizzes
+                    $quizzes = (array) array_get( $course, 'quizzes', [] );
+                    foreach ( $quizzes as $quiz ) {
+                        $ok = $this->import_quiz( $quiz, $cid );
+                        if ( $ok ) $stats['quizzes']++;
+                    }
+
+                    // certificates
+                    $certs = (array) array_get( $course, 'certificates', [] );
+                    foreach ( $certs as $cert ) {
+                        $ok = $this->import_certificate( $cert );
+                        if ( $ok ) $stats['certificates']++;
+                    }
+
+                    // enrollments (stub)
+                    $enroll = (array) array_get( $course, 'enrollments', [] );
+                    $this->stash_enrollments( $course, $enroll );
+
+                    if ( ! $this->dry_run && function_exists( 'learndash_course_set_steps' ) ) {
+                        \learndash_course_set_steps( $cid );
+                    }
                 }
 
-                // quizzes
-                $quizzes = (array) array_get( $course, 'quizzes', [] );
-                foreach ( $quizzes as $quiz ) {
-                    $ok = $this->import_quiz( $quiz, $cid );
-                    if ( $ok ) $stats['quizzes']++;
-                }
-
-                // certificates
-                $certs = (array) array_get( $course, 'certificates', [] );
-                foreach ( $certs as $cert ) {
-                    $ok = $this->import_certificate( $cert );
-                    if ( $ok ) $stats['certificates']++;
-                }
-
-                // enrollments (stub)
-                $enroll = (array) array_get( $course, 'enrollments', [] );
-                $this->stash_enrollments( $course, $enroll );
             } catch ( \Throwable $e ) {
                 $stats['errors']++;
                 $this->logger->write( 'course import failed: ' . $e->getMessage(), [ 'trace' => $e->getTraceAsString() ] );
@@ -65,8 +105,18 @@ class Importer {
         // 2) Orphans
         $orph = (array) array_get( $payload, 'orphans', [] );
         foreach ( (array) array_get( $orph, 'units', [] ) as $unit ) {
-            $ok = $this->import_lesson( $unit, 0, 0, true );
-            if ( $ok ) $stats['orphans_units']++;
+            $lres = $this->import_lesson( $unit, 0, 0, true );
+            if ( $lres ) {
+                if ( array_get( $lres, 'created' ) ) {
+                    $stats['lessons_created']++;
+                } else {
+                    $stats['lessons_updated']++;
+                }
+                if ( array_get( $lres, 'zero_duration' ) ) {
+                    $stats['lessons_zero_duration']++;
+                }
+                $stats['orphans_units']++;
+            }
         }
         foreach ( (array) array_get( $orph, 'quizzes', [] ) as $quiz ) {
             $ok = $this->import_quiz( $quiz, 0, true );
@@ -87,35 +137,105 @@ class Importer {
     private function import_course( $course ) {
         $old_id   = (int) array_get( $course, 'old_id', 0 );
         $existing = $this->idmap->get( 'courses', $old_id );
-        if ( $existing ) {
-            $this->logger->write( 'course already imported', [ 'old_id'=>$old_id, 'new_id'=>$existing ] );
-            return $existing;
+
+        $title   = array_get( $course, 'post.post_title', 'Untitled Course' );
+        $content = ensure_oembed( array_get( $course, 'post.post_content', '' ), array_get( $course, 'embeds', [] ) );
+        $slug    = normalize_slug( array_get( $course, 'current_slug', array_get( $course, 'post.post_name', '' ) ) );
+        $orig_slug = normalize_slug( array_get( $course, 'original_slug', '' ) );
+        $status  = strtolower( array_get( $course, 'post.status', 'publish' ) ) === 'publish' ? 'publish' : 'draft';
+
+        // access & price
+        $access = strtolower( array_get( $course, 'access_type_final', 'closed' ) );
+        $price_type = 'closed';
+        if ( $access === 'free' ) {
+            $price_type = 'free';
+        } elseif ( $access === 'paid' ) {
+            $price_type = 'buy now';
+        } elseif ( $access !== 'closed' && $access !== 'lead' ) {
+            $access = 'closed';
         }
 
-        $title    = array_get( $course, 'post.post_title', 'Untitled Course' );
-        $content  = array_get( $course, 'post.post_content', '' );
-        $content  = ensure_oembed( $content, array_get( $course, 'embeds', [] ) );
-        $slug     = normalize_slug( array_get( $course, 'post.post_name', '' ) );
+        $price = (float) array_get( $course, 'sale_price', 0 );
+        if ( $price <= 0 ) $price = (float) array_get( $course, 'price', 0 );
+        if ( $price <= 0 ) $price = (float) array_get( $course, 'regular_price', 0 );
+        $price = round( $price, 2 );
+        if ( $price_type === 'buy now' ) {
+            if ( $price <= 0 ) {
+                $this->logger->write( 'paid course without price, forcing closed', [ 'old_id' => $old_id ] );
+                $price_type = 'closed';
+                $access     = 'closed';
+            }
+        }
+
+        // duration
+        $duration      = (int) array_get( $course, 'duration', 0 );
+        $duration_unit = (string) array_get( $course, 'duration_unit', '' );
+        $lifetime      = ( $duration_unit === 'years' && $duration >= 99999999 );
 
         $args = [
             'post_type'    => 'sfwd-courses',
-            'post_status'  => 'publish',
+            'post_status'  => $status,
             'post_title'   => $title,
             'post_content' => $content,
         ];
         if ( $slug ) $args['post_name'] = $slug;
 
-        if ( $this->dry_run ) {
-            $this->logger->write( 'DRY: create course', [ 'title'=>$title ] );
-            return 0;
+        if ( $existing ) {
+            $args['ID'] = $existing;
+            if ( $this->dry_run ) {
+                $this->logger->write( 'DRY: update course', [ 'id' => $existing, 'title' => $title ] );
+                return [ 'id' => $existing, 'created' => false, 'access' => $access, 'lifetime' => $lifetime ];
+            }
+            $new_id = \wp_update_post( $args, true );
+            if ( \is_wp_error( $new_id ) ) {
+                throw new \RuntimeException( 'wp_update_post failed: ' . $new_id->get_error_message() );
+            }
+            $created = false;
+        } else {
+            if ( $this->dry_run ) {
+                $this->logger->write( 'DRY: create course', [ 'title' => $title ] );
+                return [ 'id' => 0, 'created' => true, 'access' => $access, 'lifetime' => $lifetime ];
+            }
+            $new_id = \wp_insert_post( $args, true );
+            if ( \is_wp_error( $new_id ) ) {
+                throw new \RuntimeException( 'wp_insert_post failed: ' . $new_id->get_error_message() );
+            }
+            \update_post_meta( $new_id, '_wplms_old_id', $old_id );
+            $created = true;
         }
 
-        $new_id = \wp_insert_post( $args, true );
-        if ( \is_wp_error( $new_id ) ) {
-            throw new \RuntimeException( 'wp_insert_post failed: ' . $new_id->get_error_message() );
+        // slug conflict tracking
+        $actual_slug = \get_post_field( 'post_name', $new_id );
+        if ( $slug && $actual_slug !== $slug ) {
+            \update_post_meta( $new_id, '_wplms_s1_requested_slug', $slug );
+        }
+        if ( $slug ) \update_post_meta( $new_id, '_wplms_s1_current_slug', $slug );
+        if ( $orig_slug ) \update_post_meta( $new_id, '_wplms_s1_original_slug', $orig_slug );
+
+        // LearnDash settings
+        if ( function_exists( 'learndash_update_setting' ) ) {
+            \learndash_update_setting( $new_id, 'course_price_type', $price_type );
+            if ( $price_type === 'buy now' && $price > 0 ) {
+                \learndash_update_setting( $new_id, 'course_price', $price );
+            } else {
+                \learndash_update_setting( $new_id, 'course_price', '' );
+            }
+        } else {
+            \update_post_meta( $new_id, 'course_price_type', $price_type );
+            if ( $price_type === 'buy now' && $price > 0 ) {
+                \update_post_meta( $new_id, 'course_price', $price );
+            } else {
+                \delete_post_meta( $new_id, 'course_price' );
+            }
         }
 
-        \update_post_meta( $new_id, '_wplms_old_id', $old_id );
+        // service meta
+        \update_post_meta( $new_id, '_wplms_s1_duration', $duration );
+        \update_post_meta( $new_id, '_wplms_s1_duration_unit', $duration_unit );
+        \update_post_meta( $new_id, '_wplms_s1_product_status', array_get( $course, 'product_status', '' ) );
+        \update_post_meta( $new_id, '_wplms_s1_product_catalog_visibility', array_get( $course, 'product_catalog_visibility', '' ) );
+        \update_post_meta( $new_id, '_wplms_s1_product_type', array_get( $course, 'product_type', '' ) );
+        \update_post_meta( $new_id, '_wplms_s1_product_inconsistent', array_get( $course, 'product_inconsistent', '' ) );
 
         // featured image (м’яко)
         try {
@@ -124,22 +244,27 @@ class Importer {
             $this->logger->write( 'featured sideload exception (course)', [ 'error' => $t->getMessage() ] );
         }
 
-        $this->idmap->set( 'courses', $old_id, $new_id );
-        return $new_id;
+        $this->idmap->set( 'courses', $old_id, $new_id, $slug );
+        return [ 'id' => $new_id, 'created' => $created, 'access' => $access, 'lifetime' => $lifetime ];
     }
 
     private function import_lesson( $unit, $course_new_id = 0, $menu_order = 0, $is_orphan = false ) {
         $old_id   = (int) array_get( $unit, 'old_id', 0 );
         $existing = $this->idmap->get( 'units', $old_id );
-        if ( $existing ) return true;
 
         $title   = array_get( $unit, 'post.post_title', 'Untitled Lesson' );
         $content = ensure_oembed( array_get( $unit, 'post.post_content', '' ), array_get( $unit, 'embeds', [] ) );
-        $slug    = normalize_slug( array_get( $unit, 'post.post_name', '' ) );
+        $slug    = normalize_slug( array_get( $unit, 'current_slug', array_get( $unit, 'post.post_name', '' ) ) );
+        $orig_slug = normalize_slug( array_get( $unit, 'original_slug', '' ) );
+        $status = strtolower( array_get( $unit, 'post.status', 'publish' ) ) === 'publish' ? 'publish' : 'draft';
+
+        $duration      = (int) array_get( $unit, 'duration', 0 );
+        $duration_unit = (string) array_get( $unit, 'duration_unit', '' );
+        $zero_duration = ( $duration <= 0 );
 
         $args = [
             'post_type'    => 'sfwd-lessons',
-            'post_status'  => 'publish',
+            'post_status'  => $status,
             'post_title'   => $title,
             'post_content' => $content,
             'menu_order'   => (int) $menu_order,
@@ -147,32 +272,59 @@ class Importer {
         ];
         if ( $slug ) $args['post_name'] = $slug;
 
-        $new_id = 0;
-
-        if ( $this->dry_run ) {
-            $this->logger->write( 'DRY: create lesson', [ 'title'=>$title, 'course'=>$course_new_id ] );
+        if ( $existing ) {
+            $args['ID'] = $existing;
+            if ( $this->dry_run ) {
+                $this->logger->write( 'DRY: update lesson', [ 'id' => $existing, 'course' => $course_new_id ] );
+                return [ 'id' => $existing, 'created' => false, 'zero_duration' => $zero_duration ];
+            }
+            $new_id = \wp_update_post( $args, true );
+            if ( \is_wp_error( $new_id ) ) {
+                $this->logger->write( 'lesson update failed: ' . $new_id->get_error_message(), [ 'old_id' => $old_id ] );
+                return false;
+            }
+            $created = false;
         } else {
+            if ( $this->dry_run ) {
+                $this->logger->write( 'DRY: create lesson', [ 'title' => $title, 'course' => $course_new_id ] );
+                return [ 'id' => 0, 'created' => true, 'zero_duration' => $zero_duration ];
+            }
             $new_id = \wp_insert_post( $args, true );
             if ( \is_wp_error( $new_id ) ) {
-                $this->logger->write( 'lesson insert failed: ' . $new_id->get_error_message(), [ 'old_id'=>$old_id ] );
+                $this->logger->write( 'lesson insert failed: ' . $new_id->get_error_message(), [ 'old_id' => $old_id ] );
                 return false;
             }
             \update_post_meta( $new_id, '_wplms_old_id', $old_id );
             if ( $course_new_id ) {
                 \update_post_meta( $new_id, 'course_id', (int) $course_new_id );
             }
-            if ( $is_orphan ) {
-                \update_post_meta( $new_id, '_wplms_orphan', 1 );
-            }
-
-            try {
-                sideload_featured( array_get( $unit, 'post.featured_image', '' ), $new_id, $this->logger );
-            } catch ( \Throwable $t ) {
-                $this->logger->write( 'featured sideload exception (lesson)', [ 'error' => $t->getMessage() ] );
-            }
-
-            $this->idmap->set( 'units', $old_id, $new_id );
+            $created = true;
         }
+
+        if ( $is_orphan ) {
+            \update_post_meta( $new_id, '_wplms_orphan', 1 );
+        }
+
+        // slug metadata
+        $actual_slug = \get_post_field( 'post_name', $new_id );
+        if ( $slug && $actual_slug !== $slug ) {
+            \update_post_meta( $new_id, '_wplms_s1_requested_slug', $slug );
+        }
+        if ( $slug ) \update_post_meta( $new_id, '_wplms_s1_current_slug', $slug );
+        if ( $orig_slug ) \update_post_meta( $new_id, '_wplms_s1_original_slug', $orig_slug );
+
+        // duration meta
+        \update_post_meta( $new_id, '_wplms_s1_duration', $duration );
+        \update_post_meta( $new_id, '_wplms_s1_duration_unit', $duration_unit );
+
+        // featured image
+        try {
+            sideload_featured( array_get( $unit, 'post.featured_image', '' ), $new_id, $this->logger );
+        } catch ( \Throwable $t ) {
+            $this->logger->write( 'featured sideload exception (lesson)', [ 'error' => $t->getMessage() ] );
+        }
+
+        $this->idmap->set( 'units', $old_id, $new_id, $slug );
 
         // assignments nested
         $assignments = (array) array_get( $unit, 'assignments', [] );
@@ -180,7 +332,7 @@ class Importer {
             $this->import_assignment( $assn, $course_new_id, $new_id, $is_orphan );
         }
 
-        return true;
+        return [ 'id' => $new_id, 'created' => $created, 'zero_duration' => $zero_duration ];
     }
 
     private function import_quiz( $quiz, $course_new_id = 0, $is_orphan = false ) {
@@ -229,7 +381,7 @@ class Importer {
             // >>> ProQuiz master record & link (fixes "Missing ProQuiz Associated Settings")
             $this->ensure_proquiz_link( $new_id, $title );
 
-            $this->idmap->set( 'quizzes', $old_id, $new_id );
+            $this->idmap->set( 'quizzes', $old_id, $new_id, $slug );
         }
 
         return true;
@@ -267,7 +419,7 @@ class Importer {
             if ( $lesson_new_id ) \update_post_meta( $new_id, 'lesson_id', (int) $lesson_new_id );
             if ( $is_orphan ) \update_post_meta( $new_id, '_wplms_orphan', 1 );
 
-            $this->idmap->set( 'assignments', $old_id, $new_id );
+            $this->idmap->set( 'assignments', $old_id, $new_id, $slug );
         }
         return true;
     }
@@ -314,7 +466,7 @@ class Importer {
                 $this->logger->write( 'certificate background skipped: empty URL' );
             }
 
-            $this->idmap->set( 'certificates', $old_id, $new_id );
+            $this->idmap->set( 'certificates', $old_id, $new_id, $slug );
         }
         return true;
     }

--- a/wplms-s1-importer/wplms-s1-importer.php
+++ b/wplms-s1-importer/wplms-s1-importer.php
@@ -28,7 +28,7 @@ if ( ! defined( 'WPLMS_S1I_URL' ) ) {
 }
 
 // Options keys
-const WPLMS_S1I_OPT_IDMAP       = 'wplms_s1i_idmap';
+const WPLMS_S1I_OPT_IDMAP       = 'wplms_s1_map';
 const WPLMS_S1I_OPT_RUNSTATS    = 'wplms_s1i_runstats';
 const WPLMS_S1I_OPT_ENROLL_POOL = 'wplms_s1i_enrollments_pool';
 


### PR DESCRIPTION
## Summary
- enhance mapping store to include slug and import timestamp
- map course access type, price, and duration metadata
- update lessons with duration metadata and track import stats

## Testing
- `php -l wplms-s1-importer/wplms-s1-importer.php`
- `php -l wplms-s1-importer/includes/IdMap.php`
- `php -l wplms-s1-importer/includes/Importer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b70971b78c832abaf1805adf59ef92