### PR TITLE
Aggregate media import metrics and quiet logs

### DIFF
--- a/wplms-s1-importer/wplms-s1-importer.php
+++ b/wplms-s1-importer/wplms-s1-importer.php
@@ -90,7 +90,12 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
             $importer->set_dry_run( $dry );
             try {
                 $stats = $importer->run( $path );
-                \WP_CLI::success( 'Done: ' . json_encode( $stats ) );
+                \WP_CLI::success( sprintf(
+                    'Media: %d %d %d',
+                    $stats['images_downloaded'] ?? 0,
+                    $stats['images_skipped_empty'] ?? 0,
+                    $stats['images_errors'] ?? 0
+                ) );
                 \WP_CLI::log( 'Log file: ' . $logger->path() );
             } catch ( \Throwable $e ) {
                 \WP_CLI::error( $e->getMessage() );


### PR DESCRIPTION
## Summary
- summarize media downloads/skips/errors at the end of import
- sideload certificate images only when present and count empty URLs without logging noise
- show media totals in WP-CLI output

## Testing
- `php -l wplms-s1-importer/includes/Importer.php`
- `php -l wplms-s1-importer/wplms-s1-importer.php`


------
https://chatgpt.com/codex/tasks/task_e_68b98daeb314832a8591799db1ab302a