### PR TITLE
Auto-register course taxonomies and attach terms

### DIFF
--- a/wplms-s1-importer/includes/Admin.php
+++ b/wplms-s1-importer/includes/Admin.php
@@ -55,6 +55,18 @@ class Admin {
                                 <h1>WPLMS → LearnDash Importer (PoC)</h1>
                                 <p>Version <?php echo \esc_html( \WPLMS_S1I_VER ); ?>. Use this to import the JSON created by WPLMS S1 Exporter.</p>
 
+                                <?php $tax_pf = (array) array_get( $stats, 'tax_preflight', [] ); ?>
+                                <?php if ( $tax_pf ) : ?>
+                                        <h2 class="title">Taxonomy preflight</h2>
+                                        <ul>
+                                                <li>course-cat: <?php echo \esc_html( array_get( $tax_pf, 'course-cat', 'n/a' ) ); ?></li>
+                                                <li>course-tag: <?php echo \esc_html( array_get( $tax_pf, 'course-tag', 'n/a' ) ); ?></li>
+                                        </ul>
+                                        <?php if ( in_array( 'created', $tax_pf, true ) ) : ?>
+                                                <p><em>URLs /course-cat/&lt;slug&gt;/ will become available after the first flush (runs automatically once).</em></p>
+                                        <?php endif; ?>
+                                <?php endif; ?>
+
                                 <?php if ( $repair_summary ) : ?>
                                         <div class="notice notice-success"><p><?php echo \esc_html( 'ProQuiz repair fixed ' . array_get( $repair_summary, 'fixed', 0 ) . ( array_get( $repair_summary, 'ids' ) ? ': ' . implode( ', ', array_map( 'intval', (array) array_get( $repair_summary, 'ids', [] ) ) ) : '' ) ); ?></p></div>
                                 <?php endif; ?>

--- a/wplms-s1-importer/wplms-s1-importer.php
+++ b/wplms-s1-importer/wplms-s1-importer.php
@@ -31,6 +31,7 @@ if ( ! defined( 'WPLMS_S1I_URL' ) ) {
 const WPLMS_S1I_OPT_IDMAP       = 'wplms_s1_map';
 const WPLMS_S1I_OPT_RUNSTATS    = 'wplms_s1i_runstats';
 const WPLMS_S1I_OPT_ENROLL_POOL = 'wplms_s1i_enrollments_pool';
+const WPLMS_S1I_OPT_NEED_FLUSH  = 'wplms_s1i_need_flush';
 
 // Autoload classes and helpers
 require_once WPLMS_S1I_DIR . 'includes/autoload.php';


### PR DESCRIPTION
## Summary
- Ensure `course-cat` and `course-tag` taxonomies exist before importing
- Create missing parent terms and update course term attachments safely
- Show taxonomy preflight status in admin and flush rewrites once

## Testing
- `php -l wplms-s1-importer.php`
- `php -l includes/Importer.php`
- `php -l includes/Admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68badd3cf8b4832abd8bc1997371627b