### PR TITLE
Use LearnDash native course taxonomies

### DIFF
--- a/wplms-s1-importer/includes/Admin.php
+++ b/wplms-s1-importer/includes/Admin.php
@@ -59,11 +59,12 @@ class Admin {
                                 <?php if ( $tax_pf ) : ?>
                                         <h2 class="title">Taxonomy preflight</h2>
                                         <ul>
-                                                <li>course-cat: <?php echo \esc_html( array_get( $tax_pf, 'course-cat', 'n/a' ) ); ?></li>
-                                                <li>course-tag: <?php echo \esc_html( array_get( $tax_pf, 'course-tag', 'n/a' ) ); ?></li>
+                                                <li>ld_course_category: <?php echo \esc_html( array_get( $tax_pf, 'ld_course_category', 'n/a' ) ); ?></li>
+                                                <li>ld_course_tag: <?php echo \esc_html( array_get( $tax_pf, 'ld_course_tag', 'n/a' ) ); ?></li>
+                                                <li>permalink_base: <?php echo \esc_html( array_get( $tax_pf, 'permalink_base', 'n/a' ) ); ?></li>
                                         </ul>
-                                        <?php if ( in_array( 'created', $tax_pf, true ) ) : ?>
-                                                <p><em>URLs /course-cat/&lt;slug&gt;/ will become available after the first flush (runs automatically once).</em></p>
+                                        <?php if ( array_get( $tax_pf, 'permalink_base' ) !== 'course-cat' ) : ?>
+                                                <p><em>Set LearnDash course category base to "course-cat" for SEO friendly URLs.</em></p>
                                         <?php endif; ?>
                                 <?php endif; ?>
 

--- a/wplms-s1-importer/includes/Importer.php
+++ b/wplms-s1-importer/includes/Importer.php
@@ -59,9 +59,8 @@ class Importer {
         // 0) Taxonomies
         $taxonomies = (array) array_get( $payload, 'taxonomies', [] );
         $has_tax = ! empty( array_get( $taxonomies, 'course-cat', [] ) ) || ! empty( array_get( $taxonomies, 'course-tag', [] ) );
-        $stats['tax_preflight'] = [];
+        $stats['tax_preflight'] = $this->ensure_taxonomies();
         if ( $has_tax ) {
-            $stats['tax_preflight'] = $this->ensure_taxonomies( $taxonomies );
             $tax_stats = $this->import_taxonomies( $taxonomies );
             $stats['course_cat_terms_created'] = array_get( $tax_stats, 'course-cat.created', 0 );
             $stats['course_cat_terms_updated'] = array_get( $tax_stats, 'course-cat.updated', 0 );
@@ -197,10 +196,6 @@ class Importer {
 
         if ( ! $this->dry_run ) {
             \update_option( \WPLMS_S1I_OPT_RUNSTATS, $stats, false );
-            if ( (int) \get_option( \WPLMS_S1I_OPT_NEED_FLUSH, 0 ) === 1 ) {
-                \flush_rewrite_rules();
-                \update_option( \WPLMS_S1I_OPT_NEED_FLUSH, 0, false );
-            }
         }
         $this->logger->write( 'Import finished', $stats );
         $this->logger->write( sprintf(
@@ -213,58 +208,18 @@ class Importer {
         return $stats;
     }
 
-    private function ensure_taxonomies( array $taxonomies ) {
+    private function ensure_taxonomies() {
         $status = [];
-        $created_any = false;
 
-        $map = [
-            'course-cat' => true,
-            'course-tag' => false,
-        ];
+        $status['ld_course_category'] = taxonomy_exists( 'ld_course_category' ) ? 'exists' : 'missing';
+        $status['ld_course_tag']      = taxonomy_exists( 'ld_course_tag' ) ? 'exists' : 'missing';
 
-        foreach ( $map as $tax => $hierarchical ) {
-            $terms = (array) array_get( $taxonomies, $tax, [] );
-            if ( ! $terms ) continue;
-
-            if ( ! taxonomy_exists( $tax ) ) {
-                $args = [
-                    'hierarchical'      => $hierarchical,
-                    'public'            => true,
-                    'show_ui'           => true,
-                    'show_in_rest'      => true,
-                    'show_admin_column' => true,
-                    'rewrite'           => [ 'slug' => $tax, 'with_front' => false ],
-                ];
-                if ( $this->dry_run ) {
-                    $this->logger->write( 'DRY: register taxonomy', [ 'taxonomy' => $tax ] );
-                } else {
-                    register_taxonomy( $tax, 'sfwd-courses', $args );
-                }
-                if ( taxonomy_exists( $tax ) ) {
-                    $status[ $tax ] = 'created';
-                    $created_any    = true;
-                } else {
-                    $status[ $tax ] = 'missing';
-                    $this->logger->write( 'taxonomy registration failed', [ 'taxonomy' => $tax ] );
-                    continue;
-                }
-            } else {
-                $status[ $tax ] = 'exists';
-            }
-
-            if ( ! is_object_in_taxonomy( 'sfwd-courses', $tax ) ) {
-                if ( $this->dry_run ) {
-                    $this->logger->write( 'DRY: attach taxonomy to sfwd-courses', [ 'taxonomy' => $tax ] );
-                } else {
-                    register_taxonomy_for_object_type( $tax, 'sfwd-courses' );
-                }
-                $status[ $tax ] = 'attached-to-sfwd-courses';
-            }
+        $permalinks = (array) \get_option( 'learndash_settings_permalinks', [] );
+        $base       = array_get( $permalinks, 'course_cat_base', '' );
+        if ( $base === '' ) {
+            $base = array_get( $permalinks, 'course_category_base', '' );
         }
-
-        if ( $created_any && ! $this->dry_run ) {
-            \update_option( \WPLMS_S1I_OPT_NEED_FLUSH, 1, false );
-        }
+        $status['permalink_base'] = $base;
 
         return $status;
     }
@@ -275,9 +230,9 @@ class Importer {
             'course-tag' => [ 'created' => 0, 'updated' => 0 ],
         ];
 
-        // course-cat with hierarchy
+        // course-cat -> ld_course_category
         $cats = (array) array_get( $taxonomies, 'course-cat', [] );
-        if ( $cats && taxonomy_exists( 'course-cat' ) ) {
+        if ( $cats && taxonomy_exists( 'ld_course_category' ) ) {
             usort( $cats, function ( $a, $b ) {
                 return count( (array) array_get( $a, 'path', [] ) ) <=> count( (array) array_get( $b, 'path', [] ) );
             } );
@@ -285,101 +240,97 @@ class Importer {
                 $slug = normalize_slug( array_get( $term, 'slug', '' ) );
                 if ( ! $slug ) continue;
                 $name = (string) array_get( $term, 'name', $slug );
-                $parent_slug = normalize_slug( array_get( $term, 'parent_slug', '' ) );
+
+                $path = (array) array_get( $term, 'path', [] );
+                $parent_slug = $path ? normalize_slug( end( $path ) ) : '';
                 if ( $parent_slug && ! isset( $this->term_index['course-cat']['slug'][ $parent_slug ] ) ) {
-                    $p = \get_term_by( 'slug', $parent_slug, 'course-cat' );
+                    $p = \get_term_by( 'slug', $parent_slug, 'ld_course_category' );
                     if ( $p ) {
-                        $this->term_index['course-cat']['slug'][ $parent_slug ] = (int) $p->term_id;
+                        $pid = (int) $p->term_id;
+                    } elseif ( $this->dry_run ) {
+                        $this->logger->write( 'DRY: create parent term', [ 'taxonomy' => 'ld_course_category', 'slug' => $parent_slug ] );
+                        $pid = 0;
                     } else {
-                        if ( $this->dry_run ) {
-                            $this->logger->write( 'DRY: create parent term', [ 'taxonomy' => 'course-cat', 'slug' => $parent_slug ] );
+                        $ins = \wp_insert_term( $parent_slug, 'ld_course_category', [ 'slug' => $parent_slug ] );
+                        if ( \is_wp_error( $ins ) ) {
+                            $this->logger->write( 'ld_course_category parent insert failed', [ 'slug' => $parent_slug, 'error' => $ins->get_error_message() ] );
                             $pid = 0;
                         } else {
-                            $ins = \wp_insert_term( $parent_slug, 'course-cat', [ 'slug' => $parent_slug ] );
-                            if ( \is_wp_error( $ins ) ) {
-                                $this->logger->write( 'course-cat parent insert failed', [ 'slug' => $parent_slug, 'error' => $ins->get_error_message() ] );
-                                $pid = 0;
-                            } else {
-                                $pid = (int) array_get( $ins, 'term_id', 0 );
-                            }
+                            $pid = (int) array_get( $ins, 'term_id', 0 );
                         }
-                        $this->term_index['course-cat']['slug'][ $parent_slug ] = $pid;
                     }
+                    $this->term_index['course-cat']['slug'][ $parent_slug ] = $pid;
                 }
                 $parent_id = $parent_slug ? ( $this->term_index['course-cat']['slug'][ $parent_slug ] ?? 0 ) : 0;
 
-                $existing = \get_term_by( 'slug', $slug, 'course-cat' );
+                $existing = \get_term_by( 'slug', $slug, 'ld_course_category' );
                 if ( $existing ) {
                     $term_id = (int) $existing->term_id;
                     $this->term_index['course-cat']['slug'][ $slug ] = $term_id;
                     $this->term_index['course-cat']['id'][ (int) array_get( $term, 'term_id', 0 ) ] = $term_id;
-                    $needs_update = false;
                     if ( $existing->name !== $name || ( $parent_id && (int) $existing->parent !== $parent_id ) ) {
-                        $needs_update = true;
-                    }
-                    if ( $needs_update ) {
                         if ( $this->dry_run ) {
-                            $this->logger->write( 'DRY: update term', [ 'taxonomy' => 'course-cat', 'slug' => $slug ] );
+                            $this->logger->write( 'DRY: update term', [ 'taxonomy' => 'ld_course_category', 'slug' => $slug ] );
                         } else {
                             $args = [ 'name' => $name ];
                             if ( $parent_id ) $args['parent'] = $parent_id;
-                            \wp_update_term( $term_id, 'course-cat', $args );
+                            \wp_update_term( $term_id, 'ld_course_category', $args );
                         }
                         $result['course-cat']['updated']++;
                     }
                 } else {
                     if ( $this->dry_run ) {
-                        $this->logger->write( 'DRY: create term', [ 'taxonomy' => 'course-cat', 'slug' => $slug ] );
+                        $this->logger->write( 'DRY: create term', [ 'taxonomy' => 'ld_course_category', 'slug' => $slug ] );
                         $term_id = 0;
                     } else {
                         $args = [ 'slug' => $slug ];
                         if ( $parent_id ) $args['parent'] = $parent_id;
-                        $inserted = \wp_insert_term( $name, 'course-cat', $args );
+                        $inserted = \wp_insert_term( $name, 'ld_course_category', $args );
                         if ( \is_wp_error( $inserted ) ) {
-                            $this->logger->write( 'course-cat insert failed', [ 'slug' => $slug, 'error' => $inserted->get_error_message() ] );
+                            $this->logger->write( 'ld_course_category insert failed', [ 'slug' => $slug, 'error' => $inserted->get_error_message() ] );
                             $term_id = 0;
                         } else {
                             $term_id = (int) array_get( $inserted, 'term_id', 0 );
                         }
                     }
                     $this->term_index['course-cat']['slug'][ $slug ] = $term_id;
-                $this->term_index['course-cat']['id'][ (int) array_get( $term, 'term_id', 0 ) ] = $term_id;
-                $result['course-cat']['created']++;
+                    $this->term_index['course-cat']['id'][ (int) array_get( $term, 'term_id', 0 ) ] = $term_id;
+                    $result['course-cat']['created']++;
+                }
             }
-        }
-        if ( $cats && ! taxonomy_exists( 'course-cat' ) ) {
-            $this->logger->write( 'course-cat taxonomy missing', [ 'fatal' => true ] );
+        } elseif ( $cats ) {
+            $this->logger->write( 'ld_course_category taxonomy missing', [ 'fatal' => true ] );
         }
 
-        // course-tag (flat)
+        // course-tag -> ld_course_tag
         $tags = (array) array_get( $taxonomies, 'course-tag', [] );
-        if ( taxonomy_exists( 'course-tag' ) ) {
+        if ( $tags && taxonomy_exists( 'ld_course_tag' ) ) {
             foreach ( $tags as $term ) {
                 $slug = normalize_slug( array_get( $term, 'slug', '' ) );
                 if ( ! $slug ) continue;
                 $name = (string) array_get( $term, 'name', $slug );
 
-                $existing = \get_term_by( 'slug', $slug, 'course-tag' );
+                $existing = \get_term_by( 'slug', $slug, 'ld_course_tag' );
                 if ( $existing ) {
                     $term_id = (int) $existing->term_id;
                     $this->term_index['course-tag']['slug'][ $slug ] = $term_id;
                     $this->term_index['course-tag']['id'][ (int) array_get( $term, 'term_id', 0 ) ] = $term_id;
                     if ( $existing->name !== $name ) {
                         if ( $this->dry_run ) {
-                            $this->logger->write( 'DRY: update term', [ 'taxonomy' => 'course-tag', 'slug' => $slug ] );
+                            $this->logger->write( 'DRY: update term', [ 'taxonomy' => 'ld_course_tag', 'slug' => $slug ] );
                         } else {
-                            \wp_update_term( $term_id, 'course-tag', [ 'name' => $name ] );
+                            \wp_update_term( $term_id, 'ld_course_tag', [ 'name' => $name ] );
                         }
                         $result['course-tag']['updated']++;
                     }
                 } else {
                     if ( $this->dry_run ) {
-                        $this->logger->write( 'DRY: create term', [ 'taxonomy' => 'course-tag', 'slug' => $slug ] );
+                        $this->logger->write( 'DRY: create term', [ 'taxonomy' => 'ld_course_tag', 'slug' => $slug ] );
                         $term_id = 0;
                     } else {
-                        $inserted = \wp_insert_term( $name, 'course-tag', [ 'slug' => $slug ] );
+                        $inserted = \wp_insert_term( $name, 'ld_course_tag', [ 'slug' => $slug ] );
                         if ( \is_wp_error( $inserted ) ) {
-                            $this->logger->write( 'course-tag insert failed', [ 'slug' => $slug, 'error' => $inserted->get_error_message() ] );
+                            $this->logger->write( 'ld_course_tag insert failed', [ 'slug' => $slug, 'error' => $inserted->get_error_message() ] );
                             $term_id = 0;
                         } else {
                             $term_id = (int) array_get( $inserted, 'term_id', 0 );
@@ -390,10 +341,9 @@ class Importer {
                     $result['course-tag']['created']++;
                 }
             }
+        } elseif ( $tags ) {
+            $this->logger->write( 'ld_course_tag taxonomy missing', [ 'fatal' => true ] );
         }
-    } elseif ( $tags ) {
-        $this->logger->write( 'course-tag taxonomy missing', [ 'fatal' => true ] );
-    }
 
         return $result;
     }
@@ -408,7 +358,7 @@ class Importer {
                 $tid = (int) $this->term_index['course-cat']['slug'][ $slug ];
                 if ( $tid ) $cat_ids[] = $tid;
             } else {
-                $this->logger->write( 'missing course-cat term for slug', [ 'slug' => $slug ] );
+                $this->logger->write( 'missing ld_course_category term for slug', [ 'slug' => $slug ] );
             }
         }
         if ( $cat_ids ) {
@@ -416,9 +366,9 @@ class Importer {
                 $this->logger->write( 'DRY: attach course categories', [ 'course' => $course_id, 'terms' => $cat_ids ] );
                 $attached += count( $cat_ids );
             } else {
-                $r = \wp_set_object_terms( $course_id, $cat_ids, 'course-cat', false );
+                $r = \wp_set_object_terms( $course_id, $cat_ids, 'ld_course_category', false );
                 if ( \is_wp_error( $r ) ) {
-                    $this->logger->write( 'course-cat attach failed', [ 'course' => $course_id, 'error' => $r->get_error_message() ] );
+                    $this->logger->write( 'ld_course_category attach failed', [ 'course' => $course_id, 'error' => $r->get_error_message() ] );
                 } else {
                     $attached += count( $cat_ids );
                 }
@@ -432,7 +382,7 @@ class Importer {
                 $tid = (int) $this->term_index['course-tag']['slug'][ $slug ];
                 if ( $tid ) $tag_ids[] = $tid;
             } else {
-                $this->logger->write( 'missing course-tag term for slug', [ 'slug' => $slug ] );
+                $this->logger->write( 'missing ld_course_tag term for slug', [ 'slug' => $slug ] );
             }
         }
         if ( $tag_ids ) {
@@ -440,9 +390,9 @@ class Importer {
                 $this->logger->write( 'DRY: attach course tags', [ 'course' => $course_id, 'terms' => $tag_ids ] );
                 $attached += count( $tag_ids );
             } else {
-                $r = \wp_set_object_terms( $course_id, $tag_ids, 'course-tag', false );
+                $r = \wp_set_object_terms( $course_id, $tag_ids, 'ld_course_tag', false );
                 if ( \is_wp_error( $r ) ) {
-                    $this->logger->write( 'course-tag attach failed', [ 'course' => $course_id, 'error' => $r->get_error_message() ] );
+                    $this->logger->write( 'ld_course_tag attach failed', [ 'course' => $course_id, 'error' => $r->get_error_message() ] );
                 } else {
                     $attached += count( $tag_ids );
                 }

--- a/wplms-s1-importer/wplms-s1-importer.php
+++ b/wplms-s1-importer/wplms-s1-importer.php
@@ -31,7 +31,6 @@ if ( ! defined( 'WPLMS_S1I_URL' ) ) {
 const WPLMS_S1I_OPT_IDMAP       = 'wplms_s1_map';
 const WPLMS_S1I_OPT_RUNSTATS    = 'wplms_s1i_runstats';
 const WPLMS_S1I_OPT_ENROLL_POOL = 'wplms_s1i_enrollments_pool';
-const WPLMS_S1I_OPT_NEED_FLUSH  = 'wplms_s1i_need_flush';
 
 // Autoload classes and helpers
 require_once WPLMS_S1I_DIR . 'includes/autoload.php';


### PR DESCRIPTION
## Summary
- Drop registration of custom `course-cat` taxonomy and rely on LearnDash's built-in `ld_course_category` and `ld_course_tag`
- Attach imported category and tag terms using the native LearnDash taxonomies
- Show taxonomy existence and permalink base in preflight diagnostics

## Testing
- `php -l wplms-s1-importer/includes/Importer.php`
- `php -l wplms-s1-importer/includes/Admin.php`
- `php -l wplms-s1-importer/wplms-s1-importer.php`


------
https://chatgpt.com/codex/tasks/task_e_68bd64a77788832ab95a1642440366a8