### PR TITLE
Ensure idempotent certificate imports and add dedupe tools

### DIFF
--- a/wplms-s1-importer/includes/IdMap.php
+++ b/wplms-s1-importer/includes/IdMap.php
@@ -6,12 +6,16 @@ class IdMap {
 
     public function __construct() {
         $this->map = \get_option( \WPLMS_S1I_OPT_IDMAP, [
-            'courses'      => [],
-            'units'        => [], // mapped to Lessons in LearnDash
-            'quizzes'      => [],
-            'assignments'  => [],
-            'certificates' => [],
+            'courses'     => [],
+            'units'       => [], // mapped to Lessons in LearnDash
+            'quizzes'     => [],
+            'assignments' => [],
+            'certificate' => [],
         ] );
+        if ( isset( $this->map['certificates'] ) && ! isset( $this->map['certificate'] ) ) {
+            $this->map['certificate'] = $this->map['certificates'];
+            unset( $this->map['certificates'] );
+        }
     }
 
     public function get_all() { return $this->map; }
@@ -35,7 +39,7 @@ class IdMap {
     }
 
     public function reset() {
-        $this->map = [ 'courses'=>[], 'units'=>[], 'quizzes'=>[], 'assignments'=>[], 'certificates'=>[] ];
+        $this->map = [ 'courses'=>[], 'units'=>[], 'quizzes'=>[], 'assignments'=>[], 'certificate'=>[] ];
         \update_option( \WPLMS_S1I_OPT_IDMAP, $this->map, false );
     }
 }

--- a/wplms-s1-importer/wplms-s1-importer.php
+++ b/wplms-s1-importer/wplms-s1-importer.php
@@ -102,5 +102,12 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
             }
         }
     } );
+    \WP_CLI::add_command( 'wplms2ld', new class {
+        public function dedupe_certificates() {
+            $idmap   = new \WPLMS_S1I\IdMap();
+            $summary = \WPLMS_S1I\cleanup_duplicate_certificates( $idmap );
+            \WP_CLI::success( sprintf( 'Groups: %d, deleted: %d', (int) \WPLMS_S1I\array_get( $summary, 'groups', 0 ), (int) \WPLMS_S1I\array_get( $summary, 'deleted', 0 ) ) );
+        }
+    } );
 }
 


### PR DESCRIPTION
## Summary
- add certificate mapping with migration and track create/update stats
- upsert certificates by `_wplms_old_id` with stable slugs and mapping updates
- expose taxonomy permalink info and add certificate dedupe tools via admin and WP-CLI

## Testing
- `php -l wplms-s1-importer/includes/IdMap.php`
- `php -l wplms-s1-importer/includes/Importer.php`
- `php -l wplms-s1-importer/includes/Admin.php`
- `php -l wplms-s1-importer/includes/helpers.php`
- `php -l wplms-s1-importer/wplms-s1-importer.php`


------
https://chatgpt.com/codex/tasks/task_e_68bee2f58618832abbdc225e502c24cf