### PR TITLE
Link imported courses to WooCommerce products

### DIFF
--- a/wplms-s1-importer/includes/helpers.php
+++ b/wplms-s1-importer/includes/helpers.php
@@ -135,6 +135,22 @@ function hv_ld_get_course_category_base(): array {
 }
 
 /**
+ * Link a LearnDash course to a WooCommerce product (soft).
+ *
+ * Updates simple meta references on both objects. No validation is performed
+ * beyond ensuring the IDs are positive integers.
+ */
+function hv_ld_link_course_to_product( $course_id, $product_id ) {
+    $course_id  = (int) $course_id;
+    $product_id = (int) $product_id;
+    if ( $course_id <= 0 || $product_id <= 0 ) {
+        return;
+    }
+    \update_post_meta( $course_id, 'ld_product_id', $product_id );
+    \update_post_meta( $product_id, 'ld_course_id', $course_id );
+}
+
+/**
  * Sideload featured image.
  * $image може бути рядком URL або масивом (url/source_url/guid/src).
  * На помилках не кидаємо фатал — пишемо в лог і повертаємо 0.


### PR DESCRIPTION
## Summary
- link imported courses to WooCommerce products using SKU, legacy product IDs or title matching
- add helper to link course and product while preserving `ld_course_access_mode`
- track statistics for course/product links

## Testing
- `php -l includes/helpers.php`
- `php -l includes/Importer.php`
- `npm test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c01753df80832a851a16c5c2bf8749