### PR TITLE
Add LearnDash course-product linking utilities

### DIFF
--- a/wplms-s1-importer/includes/helpers.php
+++ b/wplms-s1-importer/includes/helpers.php
@@ -140,16 +140,6 @@ function hv_ld_get_course_category_base(): array {
  * Updates simple meta references on both objects. No validation is performed
  * beyond ensuring the IDs are positive integers.
  */
-function hv_ld_link_course_to_product( $course_id, $product_id ) {
-    $course_id  = (int) $course_id;
-    $product_id = (int) $product_id;
-    if ( $course_id <= 0 || $product_id <= 0 ) {
-        return;
-    }
-    \update_post_meta( $course_id, 'ld_product_id', $product_id );
-    \update_post_meta( $product_id, 'ld_course_id', $course_id );
-}
-
 /**
  * Sideload featured image.
  * $image може бути рядком URL або масивом (url/source_url/guid/src).

--- a/wplms-s1-importer/includes/linking.php
+++ b/wplms-s1-importer/includes/linking.php
@@ -1,0 +1,51 @@
+<?php
+namespace WPLMS_S1I;
+
+/**
+ * Link a LearnDash course to a WooCommerce product with WooCommerce-for-LearnDash meta.
+ *
+ * Ensures the course access mode is set to closed and synchronizes WooCommerce
+ * meta arrays without creating duplicate entries on repeated calls.
+ */
+function hv_ld_link_course_to_product( int $course_id, int $product_id ): bool {
+    $course_id  = (int) $course_id;
+    $product_id = (int) $product_id;
+    if ( $course_id <= 0 || $product_id <= 0 ) {
+        return false;
+    }
+
+    // Basic cross references.
+    \update_post_meta( $course_id, 'ld_product_id', $product_id );
+    \update_post_meta( $course_id, 'ld_course_access_mode', 'closed' );
+    \update_post_meta( $product_id, 'ld_course_id', $course_id );
+
+    // WooCommerce for LearnDash meta keys require arrays keyed by course ID.
+    $meta_map = [
+        '_ld_price_type'         => 'paynow',
+        '_ld_price_billing_time' => '',
+        '_ld_price_billing_unit' => '',
+    ];
+
+    foreach ( $meta_map as $meta_key => $default ) {
+        $meta = \get_post_meta( $product_id, $meta_key, true );
+        if ( ! is_array( $meta ) ) {
+            $meta = [];
+        }
+        $meta[ $course_id ] = $default;
+        \update_post_meta( $product_id, $meta_key, $meta );
+    }
+
+    return true;
+}
+
+/**
+ * Retrieve the WooCommerce product linked to a LearnDash course.
+ */
+function hv_get_linked_product_id_for_course( int $course_id ): ?int {
+    $course_id = (int) $course_id;
+    if ( $course_id <= 0 ) {
+        return null;
+    }
+    $pid = (int) \get_post_meta( $course_id, 'ld_product_id', true );
+    return $pid > 0 ? $pid : null;
+}

--- a/wplms-s1-importer/tests/test-linking.php
+++ b/wplms-s1-importer/tests/test-linking.php
@@ -1,0 +1,51 @@
+<?php
+// Simple in-memory simulation of WordPress post meta functions.
+$GLOBALS['post_meta'] = [];
+
+function update_post_meta( $post_id, $meta_key, $value ) {
+    $GLOBALS['post_meta'][ $post_id ][ $meta_key ] = $value;
+    return true;
+}
+
+function get_post_meta( $post_id, $meta_key, $single = true ) {
+    if ( isset( $GLOBALS['post_meta'][ $post_id ][ $meta_key ] ) ) {
+        return $GLOBALS['post_meta'][ $post_id ][ $meta_key ];
+    }
+    return $single ? '' : [];
+}
+
+require __DIR__ . '/../includes/linking.php';
+
+use function WPLMS_S1I\hv_ld_link_course_to_product;
+use function WPLMS_S1I\hv_get_linked_product_id_for_course;
+
+// Link twice to ensure idempotency.
+hv_ld_link_course_to_product( 1, 100 );
+hv_ld_link_course_to_product( 1, 100 );
+
+// Verify product meta arrays contain a single entry for course ID.
+$expected = [ 1 => 'paynow' ];
+$price_types = $GLOBALS['post_meta'][100]['_ld_price_type'] ?? [];
+if ( $price_types !== $expected ) {
+    echo "Duplicate _ld_price_type entries\n";
+    exit( 1 );
+}
+$billing_times = $GLOBALS['post_meta'][100]['_ld_price_billing_time'] ?? [];
+if ( $billing_times !== [ 1 => '' ] ) {
+    echo "Duplicate _ld_price_billing_time entries\n";
+    exit( 1 );
+}
+$billing_units = $GLOBALS['post_meta'][100]['_ld_price_billing_unit'] ?? [];
+if ( $billing_units !== [ 1 => '' ] ) {
+    echo "Duplicate _ld_price_billing_unit entries\n";
+    exit( 1 );
+}
+
+// Verify accessor.
+$link = hv_get_linked_product_id_for_course( 1 );
+if ( 100 !== $link ) {
+    echo "get_linked_product_id failed\n";
+    exit( 1 );
+}
+
+echo "All tests passed\n";

--- a/wplms-s1-importer/wplms-s1-importer.php
+++ b/wplms-s1-importer/wplms-s1-importer.php
@@ -35,6 +35,7 @@ const WPLMS_S1I_OPT_ENROLL_POOL = 'wplms_s1i_enrollments_pool';
 // Autoload classes and helpers
 require_once WPLMS_S1I_DIR . 'includes/autoload.php';
 require_once WPLMS_S1I_DIR . 'includes/helpers.php';
+require_once WPLMS_S1I_DIR . 'includes/linking.php';
 
 // -----------------------------------------------------------------------------
 // Bootstrap


### PR DESCRIPTION
## Summary
- Add `hv_ld_link_course_to_product` to link courses with WooCommerce products and manage WooCommerce-for-LearnDash meta
- Provide `hv_get_linked_product_id_for_course` accessor
- Include tests ensuring repeated linking remains idempotent

## Testing
- `php wplms-s1-importer/tests/test-linking.php`


------
https://chatgpt.com/codex/tasks/task_e_68c018a42c50832a8c99d0038f25d585