### PR TITLE
Hide payment buttons for courses linked to unpublished products

### DIFF
--- a/wplms-s1-importer/wplms-s1-importer.php
+++ b/wplms-s1-importer/wplms-s1-importer.php
@@ -37,6 +37,15 @@ require_once WPLMS_S1I_DIR . 'includes/autoload.php';
 require_once WPLMS_S1I_DIR . 'includes/helpers.php';
 require_once WPLMS_S1I_DIR . 'includes/linking.php';
 
+// Hide payment buttons if linked product is not published
+add_filter( 'learndash_payment_buttons', function ( $html, $course_id ) {
+    $product_id = \WPLMS_S1I\hv_get_linked_product_id_for_course( $course_id );
+    if ( $product_id && 'publish' !== get_post_status( $product_id ) ) {
+        return '';
+    }
+    return $html;
+}, 10, 2 );
+
 // -----------------------------------------------------------------------------
 // Bootstrap
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Hide LearnDash payment buttons when the linked WooCommerce product is not published

## Testing
- `php wplms-s1-importer/tests/test-linking.php`

------
https://chatgpt.com/codex/tasks/task_e_68c019dcb6d4832aa24203a5fcd55788