### PR TITLE
Add export audit report and CSV placeholders

### DIFF
--- a/csv/courses_without_sku_DISCOVER_ALL.csv
+++ b/csv/courses_without_sku_DISCOVER_ALL.csv
@@ -1,0 +1,41 @@
+course_id,slug,title,product_status,note
+627,rappel-express1,Cours : Rappel-Express,,no_product_link
+703,preparation-a-lagilite-par-le-jeu,Cours : Préparation à l'agilité par le jeu,,no_product_link
+3285,ethique-et-bien-etre-animal,Séminaire : Éthique et bien-être animal,,no_product_link
+5152,seminaire-prevention-morsures,Prévention des morsures - Vivez-vous auprès d'une bombe à retardement ?,,no_product_link
+6004,cours-en-marche1,Cours : Sans Tension! - votre cours sur la marche en laisse,,no_product_link
+8823,webinaire-questions-et-reponses-sur-le-rappel,Webinaire - Questions et Réponses sur le Rappel !,,no_product_link
+8872,cours-focus-denfer,Cours : Focus d'Enfer! votre cours sur les jeux d'attention,,no_product_link
+9673,seminaire-biais-cognitifs-illogismes-et-persuasion,"Séminaire : Biais cognitifs, illogismes et persuasion!",,no_product_link
+11113,cours-trucs-et-tours,"Cours : Trucs et Tours! Intro au leurre, au shaping et à la fantaisie",,no_product_link
+12228,webinaire-les-pieges-a-eviter-avec-un-nouveau-chiot,Webinaire - Les pièges à éviter avec un nouveau chiot,,no_product_link
+13144,seminaire-jaime-ma-cage,Séminaire : J'aime ma Cage!,,no_product_link
+13222,webinaire-questions-reponses-sur-la-reactivite,Webinaire : Chien réactif ? Les 3 erreurs que vous faites (sans même vous en rendre compte) ! (ancien),,no_product_link
+14814,webinaire-horreur-mon-chien-tire,"Webinaire - Horreur, mon chien tire!",,no_product_link
+16151,seminaire-le-canicross-et-les-sports-atteles,Séminaire : Le canicross et les sports attelés,,no_product_link
+20059,harmonie-le-seminaire-sur-la-maisonnee-multi-chiens,Séminaire - Harmonie pour la maisonnée multi-chiens,,no_product_link
+21450,webinaire-productivite,Webinaire Pro - Productivité et organisation pour les professionnels du monde canin,,no_product_link
+32487,,Séminaire : Le guide complet sur le canicross et les sports canins attelés,,no_product_link
+37908,,Mini-séminaire pro - Le Mantrailing : le flair dans tous ses états,,no_product_link
+50910,colloque-francophone-sur-le-comportement-animal-canin-ete-2020,Colloque Francophone sur le Comportement Animal & Canin - Été 2020,,no_product_link
+56306,,Séminaire : Techniques créatives d'intervention canine «volées» au comportement aviaire,,no_product_link
+59899,mini-seminaire-la-mastication-macher-pour-resoudre-certains-problemes-de-comportement,Webinaire - La mastication chez le chien : les 5 erreurs courantes,,no_product_link
+65961,mini-seminaire-la-socialisation-du-chiot-un-cauchemar-en-temps-de-pandemie,Webinaire : La socialisation du chiot - Un cauchemar en temps de pandémie,,no_product_link
+66237,colloque-francophone-sur-le-comportement-animal-et-canin-edition-2021,Colloque Francophone sur le Comportement Animal et Canin - Édition 2021,,no_product_link
+71132,en-direct-mon-chien-mon-athlete-3-jours-de-conferences,"En direct : Mon chien, mon athlète – 3 jours de conférences",,no_product_link
+74161,conference-gratuite-venir-a-bout-des-jappements-de-votre-chien,Conférence GRATUITE - Venir à bout des jappements de votre chien !,,no_product_link
+75668,cfcac-2022,CFCAC 2022 : Peur & agression chez le chien : 4 jours de formation pour aider les chiens à problèmes,,no_product_link
+78931,conference-en-direct-mon-chien-a-mordu-je-fais-quoi-maintenant,"Webinaire - Mon chien a mordu, je fais quoi maintenant ? (ancien)",,no_product_link
+79011,,Séminaire : Le fitness canin - Les fondations du chiot au chien âgé,,no_product_link
+80054,conference-en-direct-promenades-et-rappel-diminuer-la-frustration-et-ameliorer-le-bien-etre-du-chien,Conférence en direct : Promenades en laisse et rappel - De la frustration à l'harmonie,,no_product_link
+84265,,Webinaire : Chien réactif ? Les 3 erreurs que vous faites (sans même vous en rendre compte) ! (2),,no_product_link
+89094,cfcac-2023,CFCAC 2023 [Édition Spéciale] 5 jours de formations avancées pour les professionnels et passionnés du domaine animal !,,no_product_link
+95243,seminaire-pratique-virtuel-mon-chien-de-berger-incompris-2,[Séminaire pratique virtuel] : Mon chien de berger incompris,,no_product_link
+96057,,Webinaire - L'intervenant du futur : les consultations par visioconférence ! V2,,no_product_link
+96096,,Webinaire - Comment résoudre le casse-tête de vos finances ?,,no_product_link
+100574,,Mini-séminaire pro - Comment résoudre le casse-tête de vos finances? (V2),,no_product_link
+100730,,Séminiare : Réduction du stress en milieu clinique (V2),,no_product_link
+100750,,Webinaire - Le chaînon manquant (V2),,no_product_link
+103991,7-conferences-comportement-canin,Pack de 7 conférences inédites sur le comportement canin,,no_product_link
+107781,cfcac-2024-edition-speciale-6-jours-de-formations-avancees-pour-les-professionnels-et-passionnes-du-domaine-animal,CFCAC 2024 [Édition Spéciale] 6 jours de formations avancées pour les professionnels et passionnés du domaine animal !,,no_product_link
+115158,,dsafagdsafdsa,,no_product_link

--- a/csv/courses_without_sku_DISCOVER_RELATED.csv
+++ b/csv/courses_without_sku_DISCOVER_RELATED.csv
@@ -1,0 +1,41 @@
+course_id,slug,title,product_status,note
+627,rappel-express1,Cours : Rappel-Express,,no_product_link
+703,preparation-a-lagilite-par-le-jeu,Cours : Préparation à l'agilité par le jeu,,no_product_link
+3285,ethique-et-bien-etre-animal,Séminaire : Éthique et bien-être animal,,no_product_link
+5152,seminaire-prevention-morsures,Prévention des morsures - Vivez-vous auprès d'une bombe à retardement ?,,no_product_link
+6004,cours-en-marche1,Cours : Sans Tension! - votre cours sur la marche en laisse,,no_product_link
+8823,webinaire-questions-et-reponses-sur-le-rappel,Webinaire - Questions et Réponses sur le Rappel !,,no_product_link
+8872,cours-focus-denfer,Cours : Focus d'Enfer! votre cours sur les jeux d'attention,,no_product_link
+9673,seminaire-biais-cognitifs-illogismes-et-persuasion,"Séminaire : Biais cognitifs, illogismes et persuasion!",,no_product_link
+11113,cours-trucs-et-tours,"Cours : Trucs et Tours! Intro au leurre, au shaping et à la fantaisie",,no_product_link
+12228,webinaire-les-pieges-a-eviter-avec-un-nouveau-chiot,Webinaire - Les pièges à éviter avec un nouveau chiot,,no_product_link
+13144,seminaire-jaime-ma-cage,Séminaire : J'aime ma Cage!,,no_product_link
+13222,webinaire-questions-reponses-sur-la-reactivite,Webinaire : Chien réactif ? Les 3 erreurs que vous faites (sans même vous en rendre compte) ! (ancien),,no_product_link
+14814,webinaire-horreur-mon-chien-tire,"Webinaire - Horreur, mon chien tire!",,no_product_link
+16151,seminaire-le-canicross-et-les-sports-atteles,Séminaire : Le canicross et les sports attelés,,no_product_link
+20059,harmonie-le-seminaire-sur-la-maisonnee-multi-chiens,Séminaire - Harmonie pour la maisonnée multi-chiens,,no_product_link
+21450,webinaire-productivite,Webinaire Pro - Productivité et organisation pour les professionnels du monde canin,,no_product_link
+32487,,Séminaire : Le guide complet sur le canicross et les sports canins attelés,,no_product_link
+37908,,Mini-séminaire pro - Le Mantrailing : le flair dans tous ses états,,no_product_link
+50910,colloque-francophone-sur-le-comportement-animal-canin-ete-2020,Colloque Francophone sur le Comportement Animal & Canin - Été 2020,,no_product_link
+56306,,Séminaire : Techniques créatives d'intervention canine «volées» au comportement aviaire,,no_product_link
+59899,mini-seminaire-la-mastication-macher-pour-resoudre-certains-problemes-de-comportement,Webinaire - La mastication chez le chien : les 5 erreurs courantes,,no_product_link
+65961,mini-seminaire-la-socialisation-du-chiot-un-cauchemar-en-temps-de-pandemie,Webinaire : La socialisation du chiot - Un cauchemar en temps de pandémie,,no_product_link
+66237,colloque-francophone-sur-le-comportement-animal-et-canin-edition-2021,Colloque Francophone sur le Comportement Animal et Canin - Édition 2021,,no_product_link
+71132,en-direct-mon-chien-mon-athlete-3-jours-de-conferences,"En direct : Mon chien, mon athlète – 3 jours de conférences",,no_product_link
+74161,conference-gratuite-venir-a-bout-des-jappements-de-votre-chien,Conférence GRATUITE - Venir à bout des jappements de votre chien !,,no_product_link
+75668,cfcac-2022,CFCAC 2022 : Peur & agression chez le chien : 4 jours de formation pour aider les chiens à problèmes,,no_product_link
+78931,conference-en-direct-mon-chien-a-mordu-je-fais-quoi-maintenant,"Webinaire - Mon chien a mordu, je fais quoi maintenant ? (ancien)",,no_product_link
+79011,,Séminaire : Le fitness canin - Les fondations du chiot au chien âgé,,no_product_link
+80054,conference-en-direct-promenades-et-rappel-diminuer-la-frustration-et-ameliorer-le-bien-etre-du-chien,Conférence en direct : Promenades en laisse et rappel - De la frustration à l'harmonie,,no_product_link
+84265,,Webinaire : Chien réactif ? Les 3 erreurs que vous faites (sans même vous en rendre compte) ! (2),,no_product_link
+89094,cfcac-2023,CFCAC 2023 [Édition Spéciale] 5 jours de formations avancées pour les professionnels et passionnés du domaine animal !,,no_product_link
+95243,seminaire-pratique-virtuel-mon-chien-de-berger-incompris-2,[Séminaire pratique virtuel] : Mon chien de berger incompris,,no_product_link
+96057,,Webinaire - L'intervenant du futur : les consultations par visioconférence ! V2,,no_product_link
+96096,,Webinaire - Comment résoudre le casse-tête de vos finances ?,,no_product_link
+100574,,Mini-séminaire pro - Comment résoudre le casse-tête de vos finances? (V2),,no_product_link
+100730,,Séminiare : Réduction du stress en milieu clinique (V2),,no_product_link
+100750,,Webinaire - Le chaînon manquant (V2),,no_product_link
+103991,7-conferences-comportement-canin,Pack de 7 conférences inédites sur le comportement canin,,no_product_link
+107781,cfcac-2024-edition-speciale-6-jours-de-formations-avancees-pour-les-professionnels-et-passionnes-du-domaine-animal,CFCAC 2024 [Édition Spéciale] 6 jours de formations avancées pour les professionnels et passionnés du domaine animal !,,no_product_link
+115158,,dsafagdsafdsa,,no_product_link

--- a/csv/courses_without_sku_STRICT.csv
+++ b/csv/courses_without_sku_STRICT.csv
@@ -1,0 +1,41 @@
+course_id,slug,title,product_status,note
+627,rappel-express1,Cours : Rappel-Express,,no_product_link
+703,preparation-a-lagilite-par-le-jeu,Cours : Préparation à l'agilité par le jeu,,no_product_link
+3285,ethique-et-bien-etre-animal,Séminaire : Éthique et bien-être animal,,no_product_link
+5152,seminaire-prevention-morsures,Prévention des morsures - Vivez-vous auprès d'une bombe à retardement ?,,no_product_link
+6004,cours-en-marche1,Cours : Sans Tension! - votre cours sur la marche en laisse,,no_product_link
+8823,webinaire-questions-et-reponses-sur-le-rappel,Webinaire - Questions et Réponses sur le Rappel !,,no_product_link
+8872,cours-focus-denfer,Cours : Focus d'Enfer! votre cours sur les jeux d'attention,,no_product_link
+9673,seminaire-biais-cognitifs-illogismes-et-persuasion,"Séminaire : Biais cognitifs, illogismes et persuasion!",,no_product_link
+11113,cours-trucs-et-tours,"Cours : Trucs et Tours! Intro au leurre, au shaping et à la fantaisie",,no_product_link
+12228,webinaire-les-pieges-a-eviter-avec-un-nouveau-chiot,Webinaire - Les pièges à éviter avec un nouveau chiot,,no_product_link
+13144,seminaire-jaime-ma-cage,Séminaire : J'aime ma Cage!,,no_product_link
+13222,webinaire-questions-reponses-sur-la-reactivite,Webinaire : Chien réactif ? Les 3 erreurs que vous faites (sans même vous en rendre compte) ! (ancien),,no_product_link
+14814,webinaire-horreur-mon-chien-tire,"Webinaire - Horreur, mon chien tire!",,no_product_link
+16151,seminaire-le-canicross-et-les-sports-atteles,Séminaire : Le canicross et les sports attelés,,no_product_link
+20059,harmonie-le-seminaire-sur-la-maisonnee-multi-chiens,Séminaire - Harmonie pour la maisonnée multi-chiens,,no_product_link
+21450,webinaire-productivite,Webinaire Pro - Productivité et organisation pour les professionnels du monde canin,,no_product_link
+32487,,Séminaire : Le guide complet sur le canicross et les sports canins attelés,,no_product_link
+37908,,Mini-séminaire pro - Le Mantrailing : le flair dans tous ses états,,no_product_link
+50910,colloque-francophone-sur-le-comportement-animal-canin-ete-2020,Colloque Francophone sur le Comportement Animal & Canin - Été 2020,,no_product_link
+56306,,Séminaire : Techniques créatives d'intervention canine «volées» au comportement aviaire,,no_product_link
+59899,mini-seminaire-la-mastication-macher-pour-resoudre-certains-problemes-de-comportement,Webinaire - La mastication chez le chien : les 5 erreurs courantes,,no_product_link
+65961,mini-seminaire-la-socialisation-du-chiot-un-cauchemar-en-temps-de-pandemie,Webinaire : La socialisation du chiot - Un cauchemar en temps de pandémie,,no_product_link
+66237,colloque-francophone-sur-le-comportement-animal-et-canin-edition-2021,Colloque Francophone sur le Comportement Animal et Canin - Édition 2021,,no_product_link
+71132,en-direct-mon-chien-mon-athlete-3-jours-de-conferences,"En direct : Mon chien, mon athlète – 3 jours de conférences",,no_product_link
+74161,conference-gratuite-venir-a-bout-des-jappements-de-votre-chien,Conférence GRATUITE - Venir à bout des jappements de votre chien !,,no_product_link
+75668,cfcac-2022,CFCAC 2022 : Peur & agression chez le chien : 4 jours de formation pour aider les chiens à problèmes,,no_product_link
+78931,conference-en-direct-mon-chien-a-mordu-je-fais-quoi-maintenant,"Webinaire - Mon chien a mordu, je fais quoi maintenant ? (ancien)",,no_product_link
+79011,,Séminaire : Le fitness canin - Les fondations du chiot au chien âgé,,no_product_link
+80054,conference-en-direct-promenades-et-rappel-diminuer-la-frustration-et-ameliorer-le-bien-etre-du-chien,Conférence en direct : Promenades en laisse et rappel - De la frustration à l'harmonie,,no_product_link
+84265,,Webinaire : Chien réactif ? Les 3 erreurs que vous faites (sans même vous en rendre compte) ! (2),,no_product_link
+89094,cfcac-2023,CFCAC 2023 [Édition Spéciale] 5 jours de formations avancées pour les professionnels et passionnés du domaine animal !,,no_product_link
+95243,seminaire-pratique-virtuel-mon-chien-de-berger-incompris-2,[Séminaire pratique virtuel] : Mon chien de berger incompris,,no_product_link
+96057,,Webinaire - L'intervenant du futur : les consultations par visioconférence ! V2,,no_product_link
+96096,,Webinaire - Comment résoudre le casse-tête de vos finances ?,,no_product_link
+100574,,Mini-séminaire pro - Comment résoudre le casse-tête de vos finances? (V2),,no_product_link
+100730,,Séminiare : Réduction du stress en milieu clinique (V2),,no_product_link
+100750,,Webinaire - Le chaînon manquant (V2),,no_product_link
+103991,7-conferences-comportement-canin,Pack de 7 conférences inédites sur le comportement canin,,no_product_link
+107781,cfcac-2024-edition-speciale-6-jours-de-formations-avancees-pour-les-professionnels-et-passionnes-du-domaine-animal,CFCAC 2024 [Édition Spéciale] 6 jours de formations avancées pour les professionnels et passionnés du domaine animal !,,no_product_link
+115158,,dsafagdsafdsa,,no_product_link

--- a/csv/units_in_wp_not_in_DISCOVER_ALL.csv
+++ b/csv/units_in_wp_not_in_DISCOVER_ALL.csv
@@ -1,0 +1,1 @@
+wp_id,post_title,post_status,course_id,reason,edit_link

--- a/csv/units_in_wp_not_in_DISCOVER_RELATED.csv
+++ b/csv/units_in_wp_not_in_DISCOVER_RELATED.csv
@@ -1,0 +1,1 @@
+wp_id,post_title,post_status,course_id,reason,edit_link

--- a/csv/units_in_wp_not_in_STRICT.csv
+++ b/csv/units_in_wp_not_in_STRICT.csv
@@ -1,0 +1,1 @@
+wp_id,post_title,post_status,course_id,reason,edit_link

--- a/reports/EXPORT_AUDIT.md
+++ b/reports/EXPORT_AUDIT.md
@@ -1,0 +1,45 @@
+# Export Audit
+
+This report summarizes metrics from three export modes (`strict`, `discover_all`, `discover_related`) based on JSON files in `full-export/`.
+
+## A. Metrics per Export Mode
+
+| Mode | Courses | Unique units | Unit status distribution | Courses with SKU | Courses without SKU | Product status distribution | Courses with certificate ref | Warnings |
+|---|---|---|---|---|---|---|---|---|
+| strict | 185 | 1559 | publish: 1559 | 145 | 40 | publish:127, private:5, draft:13, none:40 | 0 | 0 |
+| discover_all | 185 | 1559 | publish: 1559 | 145 | 40 | publish:127, private:5, draft:13, none:40 | 0 | 0 |
+| discover_related | 185 | 1559 | publish: 1559 | 145 | 40 | publish:127, private:5, draft:13, none:40 | 0 | 0 |
+
+Notes:
+- All three exports contain the same set of 1559 unique unit IDs, although export metadata reported 1560 units due to a duplicate (`old_id` 104143).
+- 40 courses lack product SKUs; details are listed in `csv/courses_without_sku_<MODE>.csv`.
+- No course carries a certificate reference and no warnings were produced.
+
+## B. Comparison with WP data
+
+The live WPLMS instance reports **2382** published units. Exports include only **1559** unique units, leaving **823** units absent from the JSONs. Detailed lists of missing units could not be generated because direct access to the WP database/CLI was unavailable in this environment. Placeholder CSV files are present under `csv/` for future reconciliation.
+
+## C. Venn Analysis of Unit Sets
+
+All three export modes yielded identical unit ID sets:
+
+- Units common to all modes: 1559
+- Units unique to `strict`: 0
+- Units unique to `discover_all`: 0
+- Units unique to `discover_related`: 0
+
+## D. Commerce Audit
+
+- `product_status` values observed: `publish`, `draft`, `private`, and `null` for courses without products. No unexpected statuses were found.
+- Coverage of `product_sku`: 145/185 courses (78%) include a SKU. Remaining 40 courses are detailed in CSV outputs with reasons (`no_product_link` or `product_has_no_sku`).
+
+## E. Certificates
+
+No course in any export contained a certificate reference. Without access to the WP source, potential gaps between WP and exports could not be enumerated.
+
+## Next Steps
+
+- Obtain direct WP access to identify which of the 823 units are missing and why (e.g., status filtering, lack of course association, or type mismatches).
+- Verify whether any courses in WP have certificates that are absent from exports.
+- Ensure the exporter deduplicates units correctly and clarifies unit counts in metadata.
+


### PR DESCRIPTION
## Summary
- Summarize metrics for strict, discover_all, and discover_related exports
- Add CSV outputs for courses lacking product SKUs and placeholders for missing-unit reconciliation

## Testing
- `python - <<'PY' ... (metrics computation)`


------
https://chatgpt.com/codex/tasks/task_e_68c13dc3d420832a99cad870dc233b3f