### PR TITLE
Add CLI command tests for importer

### DIFF
--- a/wplms-s1-importer/tests/test-cli-audit-json.php
+++ b/wplms-s1-importer/tests/test-cli-audit-json.php
@@ -1,0 +1,68 @@
+<?php
+require __DIR__ . '/test-stubs.php';
+require __DIR__ . '/../wplms-s1-importer.php';
+
+$cmd = WP_CLI::$commands['wplms-import'] ?? null;
+if (!$cmd) { echo "command not registered\n"; exit(1); }
+
+$root = dirname(__DIR__, 2);
+$report = $root . '/reports/IMPORT_JSON_AUDIT.md';
+$csv_course = $root . '/csv/json_courses_without_product_link.csv';
+$csv_orphan = $root . '/csv/json_orphans_units.csv';
+$files = [$report, $csv_course, $csv_orphan];
+$backup = [];
+foreach ($files as $f) {
+    $backup[$f] = file_exists($f) ? file_get_contents($f) : null;
+    if (file_exists($f)) unlink($f);
+}
+
+$json_path = __DIR__ . '/sample-audit.json';
+$payload = [
+    'courses' => [
+        [ 'id' => 10, 'slug' => 'course-10', 'title' => 'Course 10', 'meta' => ['has_product' => false] ],
+        [ 'id' => 11, 'slug' => 'course-11', 'title' => 'Course 11', 'meta' => ['has_product' => true, 'product_id' => 5] ],
+    ],
+    'orphans' => [
+        'units' => [ [ 'old_id' => 1, 'slug' => 'unit-1', 'title' => 'Unit 1', 'status' => 'draft', 'reason' => 't' ] ],
+    ],
+];
+file_put_contents($json_path, json_encode($payload));
+
+try {
+    $cmd->audit_json([], ['file' => $json_path]);
+} catch (Exception $e) {
+    foreach ($files as $f) {
+        if ($backup[$f] !== null) { file_put_contents($f, $backup[$f]); } elseif (file_exists($f)) { unlink($f); }
+    }
+    unlink($json_path);
+    echo $e->getMessage() . "\n";
+    exit(1);
+}
+
+$ok = true;
+if (!file_exists($report)) { echo "report missing\n"; $ok = false; }
+else {
+    $md = file_get_contents($report);
+    if (strpos($md, '|courses_total|2|') === false || strpos($md, '|courses_without_product_link|1|') === false || strpos($md, '|orphans_units|1|') === false) {
+        echo "report contents mismatch\n"; $ok = false;
+    }
+}
+if (!file_exists($csv_course)) { echo "course csv missing\n"; $ok = false; }
+else {
+    $rows = array_map('str_getcsv', file($csv_course));
+    if (count($rows) < 2 || $rows[1][0] !== '10') { echo "course csv mismatch\n"; $ok = false; }
+}
+if (!file_exists($csv_orphan)) { echo "orphan csv missing\n"; $ok = false; }
+else {
+    $rows2 = array_map('str_getcsv', file($csv_orphan));
+    if (count($rows2) < 2 || $rows2[1][0] !== '1') { echo "orphan csv mismatch\n"; $ok = false; }
+}
+
+unlink($json_path);
+foreach ($files as $f) {
+    if ($backup[$f] !== null) { file_put_contents($f, $backup[$f]); } elseif (file_exists($f)) { unlink($f); }
+}
+
+if (!$ok) exit(1);
+echo "audit-json test passed\n";
+?>

--- a/wplms-s1-importer/tests/test-cli-run.php
+++ b/wplms-s1-importer/tests/test-cli-run.php
@@ -1,0 +1,78 @@
+<?php
+require __DIR__ . '/test-stubs.php';
+require __DIR__ . '/../wplms-s1-importer.php';
+
+$cmd = WP_CLI::$commands['wplms-import'] ?? null;
+if (!$cmd) { echo "command not registered\n"; exit(1); }
+
+$root = dirname(__DIR__, 2);
+$report = $root . '/reports/IMPORT_RESULT.md';
+$csv_courses_missing = $root . '/csv/post_courses_without_product_link.csv';
+$csv_cert_missing = $root . '/csv/post_certificates_missing.csv';
+$csv_ou_units = $root . '/csv/post_orphans_imported_units.csv';
+$csv_ou_quizzes = $root . '/csv/post_orphans_imported_quizzes.csv';
+$csv_ou_assign = $root . '/csv/post_orphans_imported_assignments.csv';
+$csv_ou_cert = $root . '/csv/post_orphans_imported_certificates.csv';
+$files = [$report, $csv_courses_missing, $csv_cert_missing, $csv_ou_units, $csv_ou_quizzes, $csv_ou_assign, $csv_ou_cert];
+$backup = [];
+foreach ($files as $f) {
+    $backup[$f] = file_exists($f) ? file_get_contents($f) : null;
+    if (file_exists($f)) unlink($f);
+}
+
+// preset product
+$p1 = wp_insert_post(['post_type' => 'product', 'post_status' => 'publish', 'post_title' => 'Product', 'post_name' => 'product']);
+update_post_meta($p1, '_sku', 'sku1');
+
+$json_path = __DIR__ . '/sample-run.json';
+$payload = [
+    'courses' => [
+        [
+            'old_id' => 1,
+            'current_slug' => 'course-a',
+            'post' => ['post_title' => 'Course A', 'status' => 'publish'],
+            'commerce' => ['product_sku' => 'sku1'],
+        ],
+    ],
+];
+file_put_contents($json_path, json_encode($payload));
+
+try {
+    $cmd->run([], ['file' => $json_path]);
+} catch (Exception $e) {
+    foreach ($files as $f) {
+        if ($backup[$f] !== null) { file_put_contents($f, $backup[$f]); } elseif (file_exists($f)) { unlink($f); }
+    }
+    unlink($json_path);
+    echo $e->getMessage() . "\n";
+    exit(1);
+}
+
+$ok = true;
+if (!file_exists($report)) { echo "result report missing\n"; $ok = false; }
+else {
+    $md1 = file_get_contents($report);
+    if (strpos($md1, '|courses_created|1|') === false) { echo "first run report mismatch\n"; $ok = false; }
+}
+if (!file_exists($csv_courses_missing)) { echo "courses_missing csv missing\n"; $ok = false; }
+else {
+    $lines = array_filter(array_map('trim', file($csv_courses_missing)));
+    if (count($lines) !== 1) { echo "courses_missing csv not empty\n"; $ok = false; }
+}
+
+// second run should produce zero creations
+$cmd->run([], ['file' => $json_path]);
+if (!file_exists($report)) { echo "second report missing\n"; $ok = false; }
+else {
+    $md2 = file_get_contents($report);
+    if (strpos($md2, '|courses_created|0|') === false) { echo "second run not idempotent\n"; $ok = false; }
+}
+
+unlink($json_path);
+foreach ($files as $f) {
+    if ($backup[$f] !== null) { file_put_contents($f, $backup[$f]); } elseif (file_exists($f)) { unlink($f); }
+}
+
+if (!$ok) exit(1);
+echo "run command test passed\n";
+?>

--- a/wplms-s1-importer/tests/test-cli-simulate.php
+++ b/wplms-s1-importer/tests/test-cli-simulate.php
@@ -1,0 +1,74 @@
+<?php
+require __DIR__ . '/test-stubs.php';
+require __DIR__ . '/../wplms-s1-importer.php';
+
+$cmd = WP_CLI::$commands['wplms-s1'] ?? null;
+if (!$cmd) { echo "command not registered\n"; exit(1); }
+
+$root = dirname(__DIR__, 2);
+$report = $root . '/reports/IMPORT_PLAN.md';
+$csv_courses = $root . '/csv/plan_courses_linking.csv';
+$csv_orphan = $root . '/csv/plan_orphans_units.csv';
+$csv_orphan_a = $root . '/csv/plan_orphans_assignments.csv';
+$csv_orphan_q = $root . '/csv/plan_orphans_quizzes.csv';
+$csv_orphan_c = $root . '/csv/plan_orphans_certificates.csv';
+$files = [$report, $csv_courses, $csv_orphan, $csv_orphan_a, $csv_orphan_q, $csv_orphan_c];
+$backup = [];
+foreach ($files as $f) {
+    $backup[$f] = file_exists($f) ? file_get_contents($f) : null;
+    if (file_exists($f)) unlink($f);
+}
+
+$json_path = __DIR__ . '/sample-simulate.json';
+$payload = [
+    'courses' => [
+        [ 'old_id' => 1, 'current_slug' => 'course-a', 'post' => ['post_title' => 'Course A', 'status' => 'publish'] ],
+    ],
+    'orphans' => [
+        'units' => [ [ 'old_id' => 100, 'current_slug' => 'orphan-u', 'post' => ['post_title' => 'Orphan U'] ] ],
+    ],
+];
+file_put_contents($json_path, json_encode($payload));
+
+try {
+    $cmd->simulate([], ['file' => $json_path]);
+} catch (Exception $e) {
+    foreach ($files as $f) {
+        if ($backup[$f] !== null) { file_put_contents($f, $backup[$f]); } elseif (file_exists($f)) { unlink($f); }
+    }
+    unlink($json_path);
+    echo $e->getMessage() . "\n";
+    exit(1);
+}
+
+$ok = true;
+if (!file_exists($report)) { echo "plan report missing\n"; $ok = false; }
+else {
+    $md = file_get_contents($report);
+    if (strpos($md, '|courses|1|0|0|') === false || strpos($md, '|orphans_units|1|0|0|') === false) {
+        echo "plan report contents mismatch\n"; $ok = false;
+    }
+}
+if (!file_exists($csv_courses)) { echo "plan courses csv missing\n"; $ok = false; }
+else {
+    $rows = array_map('str_getcsv', file($csv_courses));
+    if (count($rows) < 2 || $rows[1][0] !== '1' || $rows[1][3] !== 'create' || $rows[1][6] !== 'not_found') {
+        echo "plan courses csv mismatch\n"; $ok = false;
+    }
+}
+if (!file_exists($csv_orphan)) { echo "plan orphans csv missing\n"; $ok = false; }
+else {
+    $rows2 = array_map('str_getcsv', file($csv_orphan));
+    if (count($rows2) < 2 || $rows2[1][0] !== '100' || $rows2[1][3] !== 'create') {
+        echo "plan orphans csv mismatch\n"; $ok = false;
+    }
+}
+
+unlink($json_path);
+foreach ($files as $f) {
+    if ($backup[$f] !== null) { file_put_contents($f, $backup[$f]); } elseif (file_exists($f)) { unlink($f); }
+}
+
+if (!$ok) exit(1);
+echo "simulate test passed\n";
+?>

--- a/wplms-s1-importer/tests/test-stubs.php
+++ b/wplms-s1-importer/tests/test-stubs.php
@@ -1,0 +1,135 @@
+<?php
+// WordPress and WP_CLI stubs for tests
+if (!defined('OBJECT')) define('OBJECT', 'OBJECT');
+if (!defined('ABSPATH')) define('ABSPATH', __DIR__);
+if (!defined('WP_CLI')) define('WP_CLI', true);
+
+$GLOBALS['posts'] = [];
+$GLOBALS['post_meta'] = [];
+$GLOBALS['options'] = [];
+$GLOBALS['filters'] = [];
+$GLOBALS['registered_post_types'] = [];
+
+function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
+    $GLOBALS['filters'][$hook][] = $callback;
+}
+function remove_filter($hook, $callback, $priority = 10) {
+    if (isset($GLOBALS['filters'][$hook])) {
+        $GLOBALS['filters'][$hook] = array_filter(
+            $GLOBALS['filters'][$hook],
+            fn($cb) => $cb !== $callback
+        );
+    }
+}
+function add_action($hook, $callback, $priority = 10, $accepted_args = 1) {
+    // Execute immediately for tests
+    $callback();
+}
+function register_post_type($post_type, $args) { $GLOBALS['registered_post_types'][$post_type] = $args; }
+function post_type_exists($post_type) { return isset($GLOBALS['registered_post_types'][$post_type]); }
+function is_admin() { return false; }
+function __return_false() { return false; }
+
+function update_post_meta($post_id, $meta_key, $value) {
+    $GLOBALS['post_meta'][$post_id][$meta_key] = $value;
+    return true;
+}
+function get_post_meta($post_id, $meta_key, $single = true) {
+    return $GLOBALS['post_meta'][$post_id][$meta_key] ?? ($single ? '' : []);
+}
+function delete_post_meta($post_id, $meta_key) {
+    unset($GLOBALS['post_meta'][$post_id][$meta_key]);
+}
+
+function wp_insert_post($args, $error = false) {
+    static $id = 1;
+    if (!isset($args['ID'])) {
+        $args['ID'] = $id++;
+    }
+    $GLOBALS['posts'][$args['ID']] = $args;
+    return $args['ID'];
+}
+function wp_update_post($args, $error = false) {
+    $id = $args['ID'];
+    $GLOBALS['posts'][$id] = array_merge($GLOBALS['posts'][$id], $args);
+    return $id;
+}
+function get_post($id) {
+    return isset($GLOBALS['posts'][$id]) ? (object) $GLOBALS['posts'][$id] : null;
+}
+function get_post_field($field, $id) {
+    return $GLOBALS['posts'][$id][$field] ?? '';
+}
+function get_post_status($id) {
+    return $GLOBALS['posts'][$id]['post_status'] ?? '';
+}
+function get_posts($args) {
+    $result = [];
+    foreach ($GLOBALS['posts'] as $id => $post) {
+        if (isset($args['post_type']) && $post['post_type'] !== $args['post_type']) continue;
+        if (isset($args['name']) && ($post['post_name'] ?? '') !== $args['name']) continue;
+        if (isset($args['meta_key'])) {
+            $key = $args['meta_key'];
+            $val = $args['meta_value'];
+            if (($GLOBALS['post_meta'][$id][$key] ?? null) !== $val) continue;
+        }
+        $result[] = $id;
+    }
+    if (isset($args['numberposts']) && $args['numberposts'] === 1) {
+        $result = array_slice($result, 0, 1);
+    }
+    if (($args['fields'] ?? '') === 'ids') return $result;
+    return array_map(fn($id) => (object) $GLOBALS['posts'][$id], $result);
+}
+function get_page_by_title($title, $output = OBJECT, $post_type = 'post') {
+    foreach ($GLOBALS['posts'] as $id => $post) {
+        if (($post['post_title'] ?? '') === $title && ($post['post_type'] ?? '') === $post_type) {
+            return (object) $post;
+        }
+    }
+    return null;
+}
+function wc_get_product_id_by_sku($sku) {
+    foreach ($GLOBALS['post_meta'] as $id => $meta) {
+        if (($meta['_sku'] ?? '') === $sku) return $id;
+    }
+    return 0;
+}
+function wp_count_posts($post_type) {
+    $count = 0;
+    foreach ($GLOBALS['posts'] as $p) {
+        if ($p['post_type'] === $post_type) $count++;
+    }
+    return (object) ['publish' => $count];
+}
+function get_option($key, $default = []) { return $GLOBALS['options'][$key] ?? $default; }
+function update_option($key, $value, $autoload = false) { $GLOBALS['options'][$key] = $value; }
+function sanitize_title($title) { $title = strtolower($title); $title = preg_replace('/[^a-z0-9]+/','-',$title); return trim($title,'-'); }
+function wp_json_encode($data, $flags = 0) { return json_encode($data, $flags); }
+function normalize_whitespace($str) { return preg_replace('/\s+/',' ', $str); }
+function wp_parse_url($url, $component = -1) { return parse_url($url, $component); }
+function wp_set_object_terms($id, $terms, $tax, $append) { return true; }
+function taxonomy_exists($t) { return false; }
+function get_terms($args) { return []; }
+function get_term_link($term, $tax) { return ''; }
+function get_the_terms($id, $tax) { return []; }
+function is_wp_error($v) { return false; }
+function wp_upload_dir() { return ['basedir' => sys_get_temp_dir()]; }
+function trailingslashit($s) { return rtrim($s,'/').'/'; }
+function wp_mkdir_p($d) { if (!is_dir($d)) mkdir($d,0777,true); return true; }
+function learndash_update_setting($id,$k,$v){ update_post_meta($id,$k,$v); }
+function learndash_get_setting($id,$k){ return get_post_meta($id,$k,true); }
+
+function plugin_dir_path($file){ return dirname($file) . '/'; }
+function plugin_dir_url($file){ return 'http://example.com/' . basename(dirname($file)) . '/'; }
+
+class WP_CLI {
+    public static $commands = [];
+    public static $logged = [];
+    public static function add_command($name, $callable) { self::$commands[$name] = $callable; }
+    public static function error($msg) { throw new Exception($msg); }
+    public static function success($msg) { self::$logged[] = $msg; }
+    public static function log($msg) { self::$logged[] = $msg; }
+    public static function warning($msg) { self::$logged[] = $msg; }
+}
+?>


### PR DESCRIPTION
## Summary
- add WordPress/WP-CLI stubs for tests
- test audit-json command produces expected reports and CSVs
- test simulate command planning and cleanup
- test run command CSV output and idempotent behavior

## Testing
- `php wplms-s1-importer/tests/test-cli-audit-json.php`
- `php wplms-s1-importer/tests/test-cli-simulate.php`
- `php wplms-s1-importer/tests/test-cli-run.php`


------
https://chatgpt.com/codex/tasks/task_e_68c181fce8a8832a94d121f38ef36f9b